### PR TITLE
Plan 12: build 15595 map insertion and object bootstrap

### DIFF
--- a/apps/cata/run_real_client_authentication.py
+++ b/apps/cata/run_real_client_authentication.py
@@ -136,7 +136,10 @@ POPULATED_CHARACTER_ENUM_PAYLOAD = (
 POPULATED_MODE = "populated-character-list"
 CHARACTER_SELECTION_MODE = "character-selection"
 INITIAL_POST_LOAD_PACKETS_MODE = "initial-post-load-packets"
-POPULATED_CHARACTER_MODES = frozenset({POPULATED_MODE, CHARACTER_SELECTION_MODE, INITIAL_POST_LOAD_PACKETS_MODE})
+MAP_INSERTION_MODE = "map-insertion-object-bootstrap"
+POPULATED_CHARACTER_MODES = frozenset({
+    POPULATED_MODE, CHARACTER_SELECTION_MODE, INITIAL_POST_LOAD_PACKETS_MODE, MAP_INSERTION_MODE,
+})
 CHARACTER_MODES = frozenset({"character-screen", *POPULATED_CHARACTER_MODES})
 CHARACTER_GUID = 0x01020304
 CHARACTER_NAME = "Cataplan"
@@ -145,6 +148,8 @@ CHARACTER_POSITION = (-8949.95, -132.493, 83.5312)
 
 
 def plan_number(mode: str) -> str:
+    if mode == MAP_INSERTION_MODE:
+        return "12"
     if mode == INITIAL_POST_LOAD_PACKETS_MODE:
         return "11"
     if mode == CHARACTER_SELECTION_MODE:
@@ -1590,7 +1595,7 @@ def run_client(args: argparse.Namespace) -> None:
                 if len(milestones) == len(CHARACTER_MILESTONES) and character_hold_started is None:
                     character_hold_started = time.monotonic()
                 if (
-                    generation["mode"] in {CHARACTER_SELECTION_MODE, INITIAL_POST_LOAD_PACKETS_MODE}
+                    generation["mode"] in {CHARACTER_SELECTION_MODE, *POST_MARKER_MODES}
                     and character_hold_started is not None and not selection_sent
                 ):
                     automate_character_selection(generation)
@@ -1602,8 +1607,9 @@ def run_client(args: argparse.Namespace) -> None:
                     and player_login_callbacks(generation)
                 ):
                     break
-                if generation["mode"] == INITIAL_POST_LOAD_PACKETS_MODE and selection_sent:
-                    if initial_packets_marker_count(generation) and post_marker_hold_started is None:
+                if generation["mode"] in POST_MARKER_MODES and selection_sent:
+                    marker_count = POST_MARKER_COUNTERS[generation["mode"]](generation)
+                    if marker_count and post_marker_hold_started is None:
                         capture_runtime(generation)
                         generation["post_marker_snapshots"] = 1
                         post_marker_hold_started = time.monotonic()
@@ -1616,7 +1622,7 @@ def run_client(args: argparse.Namespace) -> None:
                         generation["post_marker_hold_seconds"] = args.stability_seconds
                         break
                 if (
-                    generation["mode"] not in {CHARACTER_SELECTION_MODE, INITIAL_POST_LOAD_PACKETS_MODE}
+                    generation["mode"] not in {CHARACTER_SELECTION_MODE, *POST_MARKER_MODES}
                     and character_hold_started is not None
                     and time.monotonic() - character_hold_started >= args.stability_seconds
                 ):
@@ -1718,6 +1724,37 @@ def initial_packet_prefix(generation: Generation) -> list[str]:
         if selected and match and match.group(1) == "S->C":
             prefix.append(match.group(2))
     return prefix
+
+
+def map_insertion_marker_count(generation: Generation) -> int:
+    return world_log_text(generation).count("Finished object update bootstrap after adding to map")
+
+
+def map_insertion_packet_prefix(generation: Generation) -> list[str]:
+    """Packets from the Plan 11 pre-map marker through the Plan 12 post-bootstrap
+    marker: LOGIN_VERIFY_WORLD and the object/update bootstrap, not the pre-map
+    prefix Plan 11 already proved and not anything after this marker (movement/
+    control is Plan 13)."""
+    packet = re.compile(r"\b(C->S|S->C):\s+.*?\b((?:CMSG|SMSG|MSG)_[A-Z0-9_]+)\b")
+    prefix: list[str] = []
+    selected = False
+    for line in world_log_text(generation).splitlines():
+        if "Finished sending initial packets before going to map" in line:
+            selected = True
+            continue
+        if "Finished object update bootstrap after adding to map" in line:
+            break
+        match = packet.search(line)
+        if selected and match and match.group(1) == "S->C":
+            prefix.append(match.group(2))
+    return prefix
+
+
+POST_MARKER_MODES = frozenset({INITIAL_POST_LOAD_PACKETS_MODE, MAP_INSERTION_MODE})
+POST_MARKER_COUNTERS = {
+    INITIAL_POST_LOAD_PACKETS_MODE: initial_packets_marker_count,
+    MAP_INSERTION_MODE: map_insertion_marker_count,
+}
 
 
 def player_login_diagnostic(generation: Generation) -> str:
@@ -1829,6 +1866,7 @@ def sanitized_evidence(
     enumerated: dict[str, object] | None = None, screen_confirmed: bool = False,
     selection: dict[str, object] | None = None, downstream_diagnostic: str | None = None,
     initial_packet_prefix_value: list[str] | None = None, pre_map_marker_count: int | None = None,
+    map_insertion_prefix_value: list[str] | None = None, map_insertion_marker_count_value: int | None = None,
 ) -> dict[str, object]:
     auth_index = next(
         (index for index, item in enumerate(transcript) if item["opcode"] == "SMSG_AUTH_RESPONSE"), None,
@@ -1849,9 +1887,8 @@ def sanitized_evidence(
     populated_mode = generation["mode"] in POPULATED_CHARACTER_MODES
     selection_mode = generation["mode"] == CHARACTER_SELECTION_MODE
     initial_packets_mode = generation["mode"] == INITIAL_POST_LOAD_PACKETS_MODE
-    login_mode = selection_mode or initial_packets_mode
-    initial_packets_mode = generation["mode"] == INITIAL_POST_LOAD_PACKETS_MODE
-    login_mode = selection_mode or initial_packets_mode
+    map_insertion_mode = generation["mode"] == MAP_INSERTION_MODE
+    login_mode = selection_mode or initial_packets_mode or map_insertion_mode
     owned_window = owned_window_evidence(generation) if character_mode else (
         Path(generation["paths"]["raw_evidence"]) / "window.xprop"
     ).is_file()
@@ -1862,7 +1899,8 @@ def sanitized_evidence(
         "build": CLIENT_BUILD,
         "mode": generation["mode"],
         "outcome": (
-            "initial_post_load_packets_candidate" if initial_packets_mode and "characters_completed" in milestones
+            "map_insertion_object_bootstrap_candidate" if map_insertion_mode and "characters_completed" in milestones
+            else "initial_post_load_packets_candidate" if initial_packets_mode and "characters_completed" in milestones
             else "character_selection_candidate" if selection_mode and "characters_completed" in milestones
             else "populated_character_list_candidate" if populated_mode and "characters_completed" in milestones
             else "character_screen_candidate" if character_mode and "characters_completed" in milestones
@@ -1881,8 +1919,14 @@ def sanitized_evidence(
         "downstream_diagnostic": downstream_diagnostic if selection_mode else None,
         "pre_map_packet_prefix": initial_packet_prefix_value if initial_packets_mode else None,
         "pre_map_marker_count": pre_map_marker_count if initial_packets_mode else None,
-        "post_marker_hold_seconds": generation.get("post_marker_hold_seconds", 0) if initial_packets_mode else None,
-        "post_marker_snapshots": generation.get("post_marker_snapshots", 0) if initial_packets_mode else None,
+        "map_insertion_packet_prefix": map_insertion_prefix_value if map_insertion_mode else None,
+        "map_insertion_marker_count": map_insertion_marker_count_value if map_insertion_mode else None,
+        "post_marker_hold_seconds": (
+            generation.get("post_marker_hold_seconds", 0) if generation["mode"] in POST_MARKER_MODES else None
+        ),
+        "post_marker_snapshots": (
+            generation.get("post_marker_snapshots", 0) if generation["mode"] in POST_MARKER_MODES else None
+        ),
         "empty_response_payload": EMPTY_CHARACTER_ENUM_PAYLOAD if generation["mode"] == "character-screen" else None,
         "response_body": POPULATED_CHARACTER_ENUM_PAYLOAD if populated_mode else None,
         "stability_seconds": generation.get("stability_seconds", 0) if character_mode else None,
@@ -1917,7 +1961,8 @@ def verify(args: argparse.Namespace) -> None:
     populated_mode = generation["mode"] in POPULATED_CHARACTER_MODES
     selection_mode = generation["mode"] == CHARACTER_SELECTION_MODE
     initial_packets_mode = generation["mode"] == INITIAL_POST_LOAD_PACKETS_MODE
-    login_mode = selection_mode or initial_packets_mode
+    map_insertion_mode = generation["mode"] == MAP_INSERTION_MODE
+    login_mode = selection_mode or initial_packets_mode or map_insertion_mode
     rows = character_row_count(manifest, generation) if character_mode else None
     realm_count = realm_character_count(manifest, generation) if populated_mode else None
     seed = (
@@ -1944,6 +1989,8 @@ def verify(args: argparse.Namespace) -> None:
         downstream_diagnostic=player_login_diagnostic(generation) if selection_mode else None,
         initial_packet_prefix_value=initial_packet_prefix(generation) if initial_packets_mode else None,
         pre_map_marker_count=initial_packets_marker_count(generation) if initial_packets_mode else None,
+        map_insertion_prefix_value=map_insertion_packet_prefix(generation) if map_insertion_mode else None,
+        map_insertion_marker_count_value=map_insertion_marker_count(generation) if map_insertion_mode else None,
     )
     unchanged = protected_inputs_unchanged(manifest, generation)
     generation["isolation_unchanged"] = unchanged
@@ -1980,9 +2027,18 @@ def verify(args: argparse.Namespace) -> None:
                 and evidence["post_marker_hold_seconds"] >= 5
                 and evidence["post_marker_snapshots"] == 2
             )
+        if map_insertion_mode:
+            character_ok = character_ok and selection_proof_is_complete(selection, transcript, enum_events) and (
+                evidence["map_insertion_marker_count"] == 1
+                and bool(evidence["map_insertion_packet_prefix"])
+                and "SMSG_LOGIN_VERIFY_WORLD" in evidence["map_insertion_packet_prefix"]
+                and evidence["post_marker_hold_seconds"] >= 5
+                and evidence["post_marker_snapshots"] == 2
+            )
         if character_ok:
             evidence["outcome"] = (
-                "initial_post_load_packets_pass" if initial_packets_mode
+                "map_insertion_object_bootstrap_pass" if map_insertion_mode
+                else "initial_post_load_packets_pass" if initial_packets_mode
                 else "character_selection_pass" if selection_mode
                 else "populated_character_list_pass" if populated_mode else "character_screen_pass"
             )
@@ -2175,6 +2231,8 @@ def comparison_projection(evidence: dict[str, object]) -> dict[str, object]:
         "selection": evidence.get("selection"),
         "pre_map_packet_prefix": evidence.get("pre_map_packet_prefix"),
         "pre_map_marker_count": evidence.get("pre_map_marker_count"),
+        "map_insertion_packet_prefix": evidence.get("map_insertion_packet_prefix"),
+        "map_insertion_marker_count": evidence.get("map_insertion_marker_count"),
         "post_marker_hold_seconds": evidence.get("post_marker_hold_seconds"),
         "post_marker_snapshots": evidence.get("post_marker_snapshots"),
         "stability_seconds": evidence.get("stability_seconds"),
@@ -2329,6 +2387,27 @@ four Completed: COP_GET_CHARACTERS result=TRUE
     assert initial_packets_evidence["forbidden_opcodes"] == []
     assert initial_packets_evidence["pre_map_packet_prefix"] == ["SMSG_SETUP_CURRENCY"]
     assert plan_number(INITIAL_POST_LOAD_PACKETS_MODE) == "11"
+    map_insertion_generation = dict(selection_generation)
+    map_insertion_generation["mode"] = MAP_INSERTION_MODE
+    map_insertion_generation["post_marker_hold_seconds"] = 5
+    map_insertion_generation["post_marker_snapshots"] = 2
+    map_insertion_evidence = sanitized_evidence(
+        map_insertion_generation, [name for name, _ in CHARACTER_MILESTONES],
+        [{"direction": "c2s", "opcode": "CMSG_CHAR_ENUM"},
+         {"direction": "s2c", "opcode": "SMSG_CHAR_ENUM"},
+         {"direction": "c2s", "opcode": "CMSG_PLAYER_LOGIN"}],
+        character_rows=1, realm_count=1, enumerated=expected_character, screen_confirmed=True,
+        selection={
+            "action": "enter", "seeded_guid_low": CHARACTER_GUID,
+            "enumerated_guid_low": CHARACTER_GUID, "request_guid_low": CHARACTER_GUID,
+            "callback_guid_low": CHARACTER_GUID, "legit_characters_admission": True,
+        },
+        map_insertion_prefix_value=["SMSG_LOGIN_VERIFY_WORLD", "SMSG_UPDATE_OBJECT"],
+        map_insertion_marker_count_value=1,
+    )
+    assert map_insertion_evidence["forbidden_opcodes"] == []
+    assert map_insertion_evidence["map_insertion_packet_prefix"] == ["SMSG_LOGIN_VERIFY_WORLD", "SMSG_UPDATE_OBJECT"]
+    assert plan_number(MAP_INSERTION_MODE) == "12"
     assert not selection_proof_is_complete(selection_evidence["selection"], [], [])
     seed_sql = populated_character_seed_sql()
     assert "INSERT INTO `characters`" in seed_sql and "`order`,`innTriggerId`" in seed_sql
@@ -2433,7 +2512,7 @@ four Completed: COP_GET_CHARACTERS result=TRUE
         pass
     else:
         raise AssertionError("invalid state transition was accepted")
-    print("Plan 7-11 runner self-check passed")
+    print("Plan 7-12 runner self-check passed")
 
 
 def stability_seconds(value: str) -> int:
@@ -2466,7 +2545,7 @@ def parser() -> argparse.ArgumentParser:
     prepare_parser.add_argument(
         "--mode", choices=(
             "no-login", "authentication", "character-screen", POPULATED_MODE, CHARACTER_SELECTION_MODE,
-            INITIAL_POST_LOAD_PACKETS_MODE,
+            INITIAL_POST_LOAD_PACKETS_MODE, MAP_INSERTION_MODE,
         ), default="authentication",
     )
     prepare_parser.add_argument("--minimum-free-gib", type=int, default=25)

--- a/plan/12-post-load-packet-boundary.md
+++ b/plan/12-post-load-packet-boundary.md
@@ -2,4 +2,13 @@
 
 Canonical issue: [#26](https://github.com/trolloks/azerothcore-cata/issues/26)
 
-Status: blocked by Plan 11's client-accepted pre-map packet contract.
+Status: complete. Covers `AddPlayerToMap`, the typed `SMSG_LOGIN_VERIFY_WORLD` send (moved
+here from the pre-map path per the pinned Cataclysm reference, which sends it only after map
+insertion), and the first object/update bootstrap (`SendInitialPacketsAfterAddToMap`, including
+the player's own `SMSG_UPDATE_OBJECT`). Movement and player control remain out of scope for
+Plan 13.
+
+Two fresh build-15595 generations (6, 7) reached `map_insertion_object_bootstrap_pass`, each
+with `SMSG_LOGIN_VERIFY_WORLD` and `SMSG_UPDATE_OBJECT` present in the captured prefix, a single
+marker held stable for 10s across two snapshots, and a visually confirmed world-loading screen.
+`compare-last-two` found the two runs byte-identical.

--- a/src/server/game/Handlers/CharacterHandler.cpp
+++ b/src/server/game/Handlers/CharacterHandler.cpp
@@ -1075,8 +1075,18 @@ void WorldSession::HandlePlayerLoginFromDB(LoginQueryHolder const& holder)
         // Probably a hackfix, but currently the best workaround to prevent character names showing as Unknown after teleport out from instances at login.
         pCurrChar->GetSession()->SendNameQueryOpcode(pCurrChar->GetGUID());
     }
+
+    // Pinned Cataclysm sends SMSG_LOGIN_VERIFY_WORLD only after AddPlayerToMap, using
+    // wherever the player actually ended up (original position, or the teleport-out
+    // fallback above). It does not belong in SendInitialPacketsBeforeAddToMap.
+    WorldPackets::Character::LoginVerifyWorld loginVerifyWorld;
+    loginVerifyWorld.MapID = pCurrChar->GetMapId();
+    loginVerifyWorld.Pos = pCurrChar->GetPosition();
+    SendPacket(loginVerifyWorld.Write());
+
     LOG_INFO("network", "Finished sending initial packets after going to map");
     pCurrChar->SendInitialPacketsAfterAddToMap();
+    LOG_INFO("network", "Finished object update bootstrap after adding to map");
 
     if (!sToCloud9Sidecar->ClusterModeEnabled())
     {

--- a/src/server/game/Server/Packets/CharacterPackets.cpp
+++ b/src/server/game/Server/Packets/CharacterPackets.cpp
@@ -165,3 +165,14 @@ WorldPacket const* WorldPackets::Character::PlayedTime::Write()
 
     return &_worldPacket;
 }
+
+WorldPacket const* WorldPackets::Character::LoginVerifyWorld::Write()
+{
+    _worldPacket << int32(MapID);
+    _worldPacket << float(Pos.GetPositionX());
+    _worldPacket << float(Pos.GetPositionY());
+    _worldPacket << float(Pos.GetPositionZ());
+    _worldPacket << float(Pos.GetOrientation());
+
+    return &_worldPacket;
+}

--- a/src/server/game/Server/Packets/CharacterPackets.h
+++ b/src/server/game/Server/Packets/CharacterPackets.h
@@ -191,6 +191,20 @@ namespace WorldPackets
             uint32 LevelTime = 0;
             bool TriggerScriptEvent = false;
         };
+
+        // Sent once, immediately after the player is added to its map (never before);
+        // field order is int32 MapID, then Position X/Y/Z/O, matching the pinned
+        // Cataclysm reference and this fork's existing raw writer.
+        class LoginVerifyWorld final : public ServerPacket
+        {
+        public:
+            LoginVerifyWorld() : ServerPacket(SMSG_LOGIN_VERIFY_WORLD, 20) { }
+
+            WorldPacket const* Write() override;
+
+            int32 MapID = 0;
+            Position Pos;
+        };
     }
 }
 

--- a/src/test/server/game/Server/Packets/InitialPacketsTest.cpp
+++ b/src/test/server/game/Server/Packets/InitialPacketsTest.cpp
@@ -7,6 +7,7 @@
  * option) any later version.
  */
 
+#include "CharacterPackets.h"
 #include "MiscPackets.h"
 #include "MovementPackets.h"
 #include "QueryPackets.h"
@@ -93,4 +94,14 @@ TEST(InitialPacketsTest, WritesRuneModifierAndMoverPackets)
 
     WorldPackets::Movement::MoveSetActiveMover mover(ObjectGuid::Empty);
     EXPECT_EQ(PayloadHex(mover.Write()), "00");
+}
+
+TEST(InitialPacketsTest, WritesLoginVerifyWorld)
+{
+    WorldPackets::Character::LoginVerifyWorld loginVerifyWorld;
+    loginVerifyWorld.MapID = 4;
+    loginVerifyWorld.Pos = Position(1.0f, 2.0f, 3.0f, 4.0f);
+    WorldPacket const* payload = loginVerifyWorld.Write();
+    EXPECT_EQ(payload->size(), 20u);
+    EXPECT_EQ(PayloadHex(payload), "040000000000803F000000400000404000008040");
 }


### PR DESCRIPTION
## Summary
- Closes #26. Covers `Map::AddPlayerToMap` and the first object/update bootstrap boundary; movement and player control remain out of scope (Plan 13).
- Moves `SMSG_LOGIN_VERIFY_WORLD` to fire once, after `AddPlayerToMap` succeeds, matching the pinned Cataclysm reference order (it was sent before map insertion under the inherited WotLK code, and not sent at all on first login prior to this change — only on the reconnect path). Adds a typed `WorldPackets::Character::LoginVerifyWorld` packet (`int32 MapID`, `Position` X/Y/Z/O) — byte-identical to the existing raw 20-byte writer, just relocated and typed.
- Adds a runtime marker (`"Finished object update bootstrap after adding to map"`) right after `Player::SendInitialPacketsAfterAddToMap()` returns, mirroring the marker Plan 11 used for the pre-map boundary.
- Extends the real-client harness (`apps/cata/run_real_client_authentication.py`) with a `map-insertion-object-bootstrap` mode, generalizing the marker/hold/snapshot polling loop behind `POST_MARKER_MODES`/`POST_MARKER_COUNTERS` so it isn't hardcoded to Plan 11's mode.

## Test plan
- [x] `unit_tests --gtest_filter=InitialPacketsTest.*` — 5/5 pass, including new `WritesLoginVerifyWorld`
- [x] `python3 apps/cata/run_real_client_authentication.py self-check` passes
- [x] Two fresh generations (6, 7) via `prepare` → `run --auto-login` → `verify --confirm-expected-screen`, both `accepted` with outcome `map_insertion_object_bootstrap_pass`
- [x] Both show `map_insertion_marker_count == 1`, `SMSG_LOGIN_VERIFY_WORLD` and `SMSG_UPDATE_OBJECT` present in the captured prefix, `post_marker_hold_seconds == 10`, `post_marker_snapshots == 2`, no forbidden opcodes, `endpoint_ownership`/`owned_window` true, `protected_inputs_unchanged`
- [x] Screens visually confirmed via captured `window.xwd` (in-progress world-loading screen, both runs)
- [x] `compare-last-two` reports the two runs as byte-identical (`repeatable: true`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)