### PR TITLE
fix(Core): Log the first time-sync response once

### DIFF
--- a/src/server/game/Handlers/MovementHandler.cpp
+++ b/src/server/game/Handlers/MovementHandler.cpp
@@ -985,9 +985,11 @@ void WorldSession::HandleTimeSyncResp(WorldPacket& recvData)
     // serverTime = clockDelta + clientTime
 
     int64 clockDelta = (int64)serverTimeAtSent + (int64)lagDelay - (int64)clientTimestamp;
+    bool firstResponse = _timeSyncClockDeltaQueue.empty();
     _timeSyncClockDeltaQueue.put(std::pair<int64, uint32>(clockDelta, roundTripDuration));
     ComputeNewClockDelta();
-    LOG_INFO("network", "Resolved client time sync response, first in-world control liveness signal");
+    if (firstResponse)
+        LOG_INFO("network", "Resolved client time sync response, first in-world control liveness signal");
 }
 
 void WorldSession::ComputeNewClockDelta()

--- a/src/test/server/game/Server/Protocol/OpcodeTableTest.cpp
+++ b/src/test/server/game/Server/Protocol/OpcodeTableTest.cpp
@@ -34,10 +34,12 @@ TEST(OpcodeTableTest, KeepsDirectionsIndependent)
     EXPECT_EQ(table.GetOpcodeNameForLogging(serverOverlap), "[SMSG_GAMETIME_SET 0x0014 (20)]");
 
     ASSERT_NE(table[CMSG_GMTICKET_CREATE], nullptr);
-    EXPECT_EQ(table[CMSG_GMTICKET_CREATE], table[CMSG_ACCEPT_LEVEL_GRANT]);
+    ASSERT_NE(table[CMSG_ACCEPT_LEVEL_GRANT], nullptr);
+    EXPECT_NE(table[CMSG_GMTICKET_CREATE], table[CMSG_ACCEPT_LEVEL_GRANT]);
     EXPECT_STREQ(table[CMSG_GMTICKET_CREATE]->Name, "CMSG_GMTICKET_CREATE");
+    EXPECT_STREQ(table[CMSG_ACCEPT_LEVEL_GRANT]->Name, "CMSG_ACCEPT_LEVEL_GRANT");
 
-    EXPECT_EQ(table.GetOpcodeNameForLogging(MSG_MINIMAP_PING_SERVER), "[MSG_MINIMAP_PING 0x01D5 (469)]");
+    EXPECT_EQ(table.GetOpcodeNameForLogging(MSG_MINIMAP_PING_SERVER), "[MSG_MINIMAP_PING 0x6635 (26165)]");
 
     uint16 serverOnly = uint16(SMSG_AUTH_RESPONSE);
     EXPECT_NE(table.GetIncomingOpcode(serverOnly), nullptr);


### PR DESCRIPTION
## Changes Proposed:

Periodic time-sync replies were each logged as the first in-world response, causing the Plan 13 verifier to reject otherwise stable sessions. Check the existing clock-delta history before adding a sample so the marker is emitted only for the first resolved response in a session. Clock calculations and pending-request handling stay the same.

Update opcode assertions to match the current table: ticket creation and level granting use distinct handlers, and minimap ping uses `0x6635`.

- [x] Core (units, players, creatures, game systems).
- [ ] Scripts (bosses, spell scripts, creature scripts).
- [ ] Database (SAI, creatures, etc).

### AI-assisted Pull Requests

> [!IMPORTANT]
> Using AI tools to prepare pull requests is allowed, but it must be disclosed and it must follow our AC guidelines for AI Agentic Engineering (link below).
>
> You are expected to fully understand the changes you submit and to be able to explain and justify them when maintainers ask.

- [x] AI tools were used entirely or partially to prepare this pull request.
  - Tools/models used: OpenAI Codex, GPT-6, for validation, self-review, and PR preparation. This session did not modify the two existing commits.
- [ ] I have read and understood the [AC guidelines for AI Agentic Engineering](https://www.azerothcore.org/wiki/agentic-engineering)

## Issues Addressed:

Related to #27. Keep the issue open while its strict repeatability comparison remains failing.

## SOURCE:

- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick).

## Tests Performed:

Validation and self-review are pinned to `2fcea45f21e71366df337edfeaa20dc62355badc`.

- Rebuilt `revision.h`, `worldserver`, `authserver`, and `unit_tests` in the existing Release build. Both servers report the reviewed commit.
- The C++ test suite, client runner self-check, focus regression check, SQL codestyle, and `git diff --check` passed.
- Codex drove two fresh isolated build-15595 clients using the rebuilt binaries directly. Both screenshots showed Cataplan in Northshire.

| Generation | Requests / replies | First-response markers | Stable hold | Individual verification | Owned reset |
| --- | --- | --- | --- | --- | --- |
| 80 | 4 / 4 | 1 | 30 seconds | PASS | PASS |
| 81 | 4 / 4 | 1 | 30 seconds | PASS | PASS |

Protected client and personal Bottle inputs remained unchanged. The owned containers and database volumes were removed.

- [ ] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [x] This pull request requires further testing and may have edge cases to be tested.

Self-review found no actionable issue in the two-file diff. The check limitations below remain.

## How to Test the Changes:

- [x] This pull request can be tested by following the reproduction steps provided in the linked issue.
- [x] This pull request requires further testing. Provide steps to test your changes.

1. Run the opcode regression suite and confirm ticket creation and level granting resolve to distinct handlers, with minimap ping logged as `0x6635`.
2. Using the isolated setup documented in `plan/client-automation.md`, enter the world with a build-15595 client and hold the session for 30 seconds after the first resolved time-sync response.
3. Confirm subsequent replies continue to resolve while the first-response marker remains at one. Verify the saved evidence and reset only the run-owned resources.

## Known Issues and TODO List:

- [ ] `compare-last-two` fails because the packet sequences before the first resolved response differ in creature queries and background updates. Every other saved evidence field matches. Both individual verifications passed; strict repeatability is not claimed.
- [ ] Repository-wide C++ codestyle fails on existing multiple blank lines in `UpdateFields.h` at lines 40, 186, and 522. That file is unchanged from `origin/master`; neither changed file has a reported violation.

## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
