### PR TITLE
fix(Core): Compare time-sync acceptance evidence

### DIFF
--- a/apps/cata/run_real_client_authentication.py
+++ b/apps/cata/run_real_client_authentication.py
@@ -2324,7 +2324,10 @@ def comparison_projection(evidence: dict[str, object]) -> dict[str, object]:
         "pre_map_marker_count": evidence.get("pre_map_marker_count"),
         "map_insertion_packet_prefix": evidence.get("map_insertion_packet_prefix"),
         "map_insertion_marker_count": evidence.get("map_insertion_marker_count"),
-        "in_world_control_packet_prefix": evidence.get("in_world_control_packet_prefix"),
+        # Background queries and NPC updates vary before the first resolved response.
+        "in_world_control_response_observed": (
+            "C->S:CMSG_TIME_SYNC_RESP" in (evidence.get("in_world_control_packet_prefix") or [])
+        ),
         "in_world_control_marker_count": evidence.get("in_world_control_marker_count"),
         "post_marker_hold_seconds": evidence.get("post_marker_hold_seconds"),
         "post_marker_snapshots": evidence.get("post_marker_snapshots"),
@@ -2526,6 +2529,26 @@ four Completed: COP_GET_CHARACTERS result=TRUE
         "S->C:SMSG_TIME_SYNC_REQ", "C->S:CMSG_TIME_SYNC_RESP",
     ]
     assert plan_number(IN_WORLD_CONTROL_MODE) == "13"
+    accepted_control_evidence = {
+        **in_world_control_evidence, "outcome": "in_world_control_bootstrap_pass",
+        "endpoint_ownership": True, "protected_inputs_unchanged": True, "reset": "PASS",
+    }
+    control_comparison = comparison_projection(accepted_control_evidence)
+    assert control_comparison == comparison_projection({
+        **accepted_control_evidence,
+        "in_world_control_packet_prefix": [
+            "S->C:SMSG_MONSTER_MOVE", "C->S:CMSG_CREATURE_QUERY", "C->S:CMSG_TIME_SYNC_RESP",
+        ],
+    })
+    for key, value in (
+        ("in_world_control_packet_prefix", ["S->C:SMSG_TIME_SYNC_REQ"]),
+        ("in_world_control_marker_count", 0), ("in_world_control_marker_count", 2),
+        ("post_marker_hold_seconds", 0), ("post_marker_snapshots", 1),
+        ("endpoint_ownership", False), ("screen_confirmed", False),
+        ("protected_inputs_unchanged", False), ("reset", "FAIL"),
+        ("outcome", "inconclusive"), ("inputs", {}),
+    ):
+        assert control_comparison != comparison_projection({**accepted_control_evidence, key: value}), key
     assert not selection_proof_is_complete(selection_evidence["selection"], [], [])
     seed_sql = populated_character_seed_sql()
     assert "INSERT INTO `characters`" in seed_sql and "`order`,`innTriggerId`" in seed_sql

--- a/plan/conversion-roadmap.md
+++ b/plan/conversion-roadmap.md
@@ -206,7 +206,10 @@ world control. Plan 10 proved `Player::LoadFromDB` returned true as a diagnostic
 pre-map packet contract; Plan 12 proved map insertion and object bootstrap, moving `SMSG_LOGIN_VERIFY_WORLD`
 to fire after map insertion per the pinned Cataclysm reference. On 2026-09-08, the real client entered
 Northshire and completed 10 matched time-sync exchanges after correcting aura flags and two guild
-requests in a diagnostic relay. Plans 14 and 21 reached their world-entry stopping point; the source
-fixes await the next authorized build. [Evidence and limits](client-automation.md#resolved-loading-screen-hang-aura-flags-2026-09-08).
-Plan 13 remains open for its two-fresh-generation acceptance. Plans 15-16 cover movement and remain
-separate from this passive world-entry proof.
+requests in a diagnostic relay. Plans 14 and 21 reached their world-entry stopping point.
+[Earlier evidence and limits](client-automation.md#resolved-loading-screen-hang-aura-flags-2026-09-08).
+Plan 13 subsequently passed with rebuilt binaries in fresh generations 80 and 81, each with four matched
+time-sync exchanges, one first-response marker, a 30-second stable hold, and a clean owned reset.
+The comparison checks the required response and acceptance evidence while retaining variable background
+packet sequences for diagnosis. [Completion evidence](https://github.com/trolloks/azerothcore-cata/issues/27).
+Plans 15-16 cover movement and remain separate from this passive world-entry proof.

--- a/plan/github-issues.tsv
+++ b/plan/github-issues.tsv
@@ -11,7 +11,7 @@ plan	issue	state	title	url
 10	20	closed	Plan 10: select the enumerated build 15595 character	https://github.com/trolloks/azerothcore-cata/issues/20
 11	25	closed	Plan 11: build 15595 initial post-load packet contract	https://github.com/trolloks/azerothcore-cata/issues/25
 12	26	closed	Plan 12: build 15595 map insertion and object bootstrap	https://github.com/trolloks/azerothcore-cata/issues/26
-13	27	open	Plan 13: build 15595 in-world control bootstrap	https://github.com/trolloks/azerothcore-cata/issues/27
+13	27	closed	Plan 13: build 15595 in-world control bootstrap	https://github.com/trolloks/azerothcore-cata/issues/27
 14	32	closed	Plan 14: build 15595 post-map-insertion client survival	https://github.com/trolloks/azerothcore-cata/issues/32
 15	33	open	Plan 15: build 15595 basic movement packet contract	https://github.com/trolloks/azerothcore-cata/issues/33
 16	34	open	Plan 16: build 15595 movement acknowledgement and speed contract	https://github.com/trolloks/azerothcore-cata/issues/34


### PR DESCRIPTION
## Changes Proposed:

Two accepted Plan 13 runs were rejected by `compare-last-two` because creature queries and background updates differed before the first resolved time-sync reply. Compare whether the required reply was observed, retaining the full packet sequence in saved evidence for diagnosis. The existing acceptance gates and all other comparison fields remain in place.

Add a regression check for variable background traffic and mismatched acceptance evidence. Update the roadmap and issue index for Plan 13 completion.

- [ ] Core (units, players, creatures, game systems).
- [ ] Scripts (bosses, spell scripts, creature scripts).
- [ ] Database (SAI, creatures, etc).

This change affects the verification tool and plan records.

### AI-assisted Pull Requests

> [!IMPORTANT]
> Using AI tools to prepare pull requests is allowed, but it must be disclosed and it must follow our AC guidelines for AI Agentic Engineering (link below).
>
> You are expected to fully understand the changes you submit and to be able to explain and justify them when maintainers ask.

- [x] AI tools were used entirely or partially to prepare this pull request.
  - Tools/models used: OpenAI Codex, GPT-6, for implementation, tests, self-review, and PR preparation.
- [ ] I have read and understood the [AC guidelines for AI Agentic Engineering](https://www.azerothcore.org/wiki/agentic-engineering)

## Issues Addressed:

Completes the comparison work for #27 after #46. The existing client evidence now passes repeatability checking.

## SOURCE:

- [ ] Live research (checked on live servers, e.g Classic WotLK, Retail, etc.)
- [ ] Sniffs (remember to share them with the open source community!)
- [ ] Video evidence, knowledge databases or other public sources (e.g forums, Wowhead, etc.)
- [ ] The changes promoted by this pull request come partially or entirely from another project (cherry-pick).

## Tests Performed:

- Reproduced the original comparison failure against saved generations 80 and 81. The new regression assertion failed before the fix.
- `python3 apps/cata/run_real_client_authentication.py self-check` passes. It covers variable background traffic and mismatches in reply presence, marker count, hold duration, snapshots, endpoint ownership, screen confirmation, protected inputs, reset, outcome, and binary/data identities.
- `compare-last-two` now returns `{"generations": [80, 81], "repeatable": true, "replay_passed": false}`. The replay flag concerns the separate authentication-mode replay and is not required for Plan 13.
- Both saved runs have four matched time-sync exchanges, one first-response marker after map insertion, a 30-second hold, visual confirmation of Northshire, unchanged protected inputs, and passing owned resets.
- SQL codestyle and `git diff --check` pass. C++ codestyle reports only the three existing blank-line violations in unchanged `UpdateFields.h`.
- Self-review pinned to `0891212f41cfc175863b71656db96a481868ee41`. No actionable findings in this diff.

No rebuild or new client runs were performed. The merged server source matches the source used by generations 80 and 81.

- [ ] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [ ] This pull request requires further testing and may have edge cases to be tested.

## How to Test the Changes:

- [ ] This pull request can be tested by following the reproduction steps provided in the linked issue.
- [ ] This pull request requires further testing. Provide steps to test your changes.

1. Run `python3 apps/cata/run_real_client_authentication.py self-check`.
2. Run `python3 apps/cata/run_real_client_authentication.py compare-last-two --manifest <saved-manifest>` against the existing accepted and reset generations 80 and 81. Confirm `repeatable` is true.

## Known Issues and TODO List:

- [ ] Existing C++ codestyle failures in `UpdateFields.h` at lines 40, 186, and 522 remain outside this change.

## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
