### PR TITLE
fix(Core): Decode Cataclysm movement heartbeats

### DIFF
--- a/apps/cata/generate_movement_fixtures.py
+++ b/apps/cata/generate_movement_fixtures.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+"""Print synthetic movement fixtures from the pinned TrinityCore packet sequences."""
+
+import argparse
+import json
+import re
+import struct
+import subprocess
+
+PIN = "c699217775d90794158422387b07a917e161b582"
+
+
+def encode(sequence, sample):
+    output = bytearray()
+    bits = []
+
+    def flush():
+        if bits:
+            output.append(sum(value << (7 - index) for index, value in enumerate(bits)))
+            bits.clear()
+
+    def bit(value):
+        bits.append(int(bool(value)))
+        if len(bits) == 8:
+            flush()
+
+    inverted = {
+        "MovementFlags", "MovementFlags2", "Timestamp", "Orientation", "SplineElevation", "Pitch",
+    }
+    conditions = {name: bool(sample.get(name, 0)) for name in inverted}
+    conditions.update({
+        "TransportData": bool(sample.get("TransportGuid", 0)),
+        "TransportTime2": bool(sample.get("TransportTime2", 0)),
+        "VehicleId": bool(sample.get("TransportVehicleId", 0)),
+        "FallData": bool(sample.get("FallTime", 0) or sample.get("MovementFlags", 0) & 0x800),
+        "FallDirection": bool(sample.get("MovementFlags", 0) & 0x800),
+        "Spline": False, "HeightChangeFailed": False,
+    })
+    if sequence[0] == "MSEHasFallData":
+        conditions["Timestamp"] = True
+    for element in sequence:
+        name = element.removeprefix("MSE")
+        if name == "End":
+            break
+        if name.startswith("HasTransportGuidByte") or name in {"HasVehicleId", "HasTransportTime2"}:
+            if not conditions["TransportData"]:
+                continue
+        if name == "HasFallDirection" and not conditions["FallData"]:
+            continue
+        guid = re.fullmatch(r"(Has)?(Transport)?GuidByte([0-7])", name)
+        if guid:
+            presence, transport, index = guid.groups()
+            if transport and not conditions["TransportData"]:
+                continue
+            value = (sample.get("TransportGuid" if transport else "Guid", 0) >> (int(index) * 8)) & 255
+            if presence:
+                bit(value)
+            elif value:
+                flush()
+                output.append(value ^ 1)
+        elif name.startswith("Has"):
+            field = name[3:]
+            bit(not conditions[field] if field in inverted else conditions[field])
+        elif name in {"ZeroBit", "OneBit"}:
+            bit(name == "OneBit")
+        elif name == "FlushBits":
+            flush()
+        elif name in {"MovementFlags", "MovementFlags2"}:
+            if conditions[name]:
+                for shift in reversed(range(30 if name == "MovementFlags" else 12)):
+                    bit((sample[name] >> shift) & 1)
+        else:
+            if name in conditions and not conditions[name]:
+                continue
+            if name.startswith("Transport"):
+                if not conditions["TransportData"]:
+                    continue
+                if name == "TransportVehicleId" and not conditions["VehicleId"]:
+                    continue
+            if name.startswith("Fall"):
+                if not conditions["FallData"]:
+                    continue
+                if name in {"FallHorizontalSpeed", "FallCosAngle", "FallSinAngle"} and not conditions["FallDirection"]:
+                    continue
+            format_code = "f"
+            if name in {"Timestamp", "FallTime", "TransportTime", "TransportTime2", "TransportVehicleId"}:
+                format_code = "I"
+            elif name == "TransportSeat":
+                format_code = "b"
+            flush()
+            output.extend(struct.pack("<" + format_code, sample.get(name, 0)))
+    flush()
+    return output.hex().upper()
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--trinity-repo", required=True)
+    args = parser.parse_args()
+    source = subprocess.check_output([
+        "git", "-C", args.trinity_repo, "show", PIN + ":src/server/game/Movement/MovementStructures.cpp",
+    ], text=True)
+    sequences = {}
+    for name in ("MovementHeartBeat", "MovementUpdate"):
+        body = re.search(r"\b" + name + r"\[\]\s*=\s*\{(.*?)\};", source, re.S).group(1)
+        sequences[name] = re.findall(r"\bMSE\w+", body)
+    samples = {
+        "idle": {"Guid": 0x01020304, "PositionX": 1, "PositionY": 2, "PositionZ": 3, "Timestamp": 0x01020304},
+        "sparse": {"Guid": 0x0010000000000001, "PositionX": -1, "PositionY": 2, "PositionZ": 3},
+        "optional": {
+            "Guid": 0x0807060504030201, "PositionX": 1.25, "PositionY": -2.5, "PositionZ": 3.75,
+            "Orientation": 1.5, "Timestamp": 0x11223344, "MovementFlags": 0x02000800, "MovementFlags2": 0x10,
+            "TransportGuid": 0x1020304050607080, "TransportPositionX": 6.25, "TransportPositionY": 7.5,
+            "TransportPositionZ": -8.75, "TransportOrientation": 2, "TransportSeat": -1,
+            "TransportTime": 42, "TransportTime2": 43, "TransportVehicleId": 44,
+            "FallTime": 77, "FallVerticalSpeed": -4.25, "FallHorizontalSpeed": 5.5,
+            "FallCosAngle": 0.75, "FallSinAngle": -0.5, "Pitch": -0.25, "SplineElevation": 0.25,
+        },
+    }
+    print(json.dumps({name: {packet: encode(sequence, sample) for packet, sequence in sequences.items()}
+                      for name, sample in samples.items()}, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/apps/cata/run_real_client_authentication.py
+++ b/apps/cata/run_real_client_authentication.py
@@ -138,9 +138,10 @@ CHARACTER_SELECTION_MODE = "character-selection"
 INITIAL_POST_LOAD_PACKETS_MODE = "initial-post-load-packets"
 MAP_INSERTION_MODE = "map-insertion-object-bootstrap"
 IN_WORLD_CONTROL_MODE = "in-world-control-bootstrap"
+BASIC_MOVEMENT_MODE = "basic-movement"
 POPULATED_CHARACTER_MODES = frozenset({
     POPULATED_MODE, CHARACTER_SELECTION_MODE, INITIAL_POST_LOAD_PACKETS_MODE, MAP_INSERTION_MODE,
-    IN_WORLD_CONTROL_MODE,
+    IN_WORLD_CONTROL_MODE, BASIC_MOVEMENT_MODE,
 })
 CHARACTER_MODES = frozenset({"character-screen", *POPULATED_CHARACTER_MODES})
 CHARACTER_GUID = 0x01020304
@@ -154,6 +155,8 @@ CHARACTER_ZONE = 12
 
 
 def plan_number(mode: str) -> str:
+    if mode == BASIC_MOVEMENT_MODE:
+        return "15"
     if mode == IN_WORLD_CONTROL_MODE:
         return "13"
     if mode == MAP_INSERTION_MODE:
@@ -789,7 +792,7 @@ def write_configs(manifest: Manifest, generation: Generation) -> None:
         "SOAP.Enabled": "0",
         "Cluster.Enabled": "0",
         "Appender.Server": '2,5,0,WorldServer.log,w',
-        "Logger.network": "4,Server",
+        "Logger.network": "5,Server" if generation["mode"] == BASIC_MOVEMENT_MODE else "4,Server",
         "Logger.network.opcode": "4,Server",
     }
     auth_source = (REPO_ROOT / "src/server/apps/authserver/authserver.conf.dist").read_text()
@@ -1819,11 +1822,23 @@ def in_world_control_packet_prefix(generation: Generation) -> list[str]:
     return prefix
 
 
-POST_MARKER_MODES = frozenset({INITIAL_POST_LOAD_PACKETS_MODE, MAP_INSERTION_MODE, IN_WORLD_CONTROL_MODE})
+MOVEMENT_HEARTBEAT_MARKER = "Accepted Cataclysm movement heartbeat after movement validation"
+
+
+def movement_heartbeat_count(generation: Generation) -> int:
+    after_map = world_log_text(generation).partition("Finished object update bootstrap after adding to map")[2]
+    after_sync = after_map.partition(IN_WORLD_CONTROL_MARKER)[2]
+    return after_sync.count(MOVEMENT_HEARTBEAT_MARKER)
+
+
+POST_MARKER_MODES = frozenset({
+    INITIAL_POST_LOAD_PACKETS_MODE, MAP_INSERTION_MODE, IN_WORLD_CONTROL_MODE, BASIC_MOVEMENT_MODE,
+})
 POST_MARKER_COUNTERS = {
     INITIAL_POST_LOAD_PACKETS_MODE: initial_packets_marker_count,
     MAP_INSERTION_MODE: map_insertion_marker_count,
     IN_WORLD_CONTROL_MODE: in_world_control_marker_count,
+    BASIC_MOVEMENT_MODE: movement_heartbeat_count,
 }
 
 
@@ -1938,6 +1953,7 @@ def sanitized_evidence(
     initial_packet_prefix_value: list[str] | None = None, pre_map_marker_count: int | None = None,
     map_insertion_prefix_value: list[str] | None = None, map_insertion_marker_count_value: int | None = None,
     in_world_control_prefix_value: list[str] | None = None, in_world_control_marker_count_value: int | None = None,
+    movement_heartbeat_count_value: int | None = None,
 ) -> dict[str, object]:
     auth_index = next(
         (index for index, item in enumerate(transcript) if item["opcode"] == "SMSG_AUTH_RESPONSE"), None,
@@ -1959,7 +1975,8 @@ def sanitized_evidence(
     selection_mode = generation["mode"] == CHARACTER_SELECTION_MODE
     initial_packets_mode = generation["mode"] == INITIAL_POST_LOAD_PACKETS_MODE
     map_insertion_mode = generation["mode"] == MAP_INSERTION_MODE
-    in_world_control_mode = generation["mode"] == IN_WORLD_CONTROL_MODE
+    basic_movement_mode = generation["mode"] == BASIC_MOVEMENT_MODE
+    in_world_control_mode = generation["mode"] in {IN_WORLD_CONTROL_MODE, BASIC_MOVEMENT_MODE}
     login_mode = selection_mode or initial_packets_mode or map_insertion_mode or in_world_control_mode
     owned_window = owned_window_evidence(generation) if character_mode else (
         Path(generation["paths"]["raw_evidence"]) / "window.xprop"
@@ -1971,7 +1988,8 @@ def sanitized_evidence(
         "build": CLIENT_BUILD,
         "mode": generation["mode"],
         "outcome": (
-            "in_world_control_bootstrap_candidate" if in_world_control_mode and "characters_completed" in milestones
+            "basic_movement_pass_candidate" if basic_movement_mode and "characters_completed" in milestones
+            else "in_world_control_bootstrap_candidate" if in_world_control_mode and "characters_completed" in milestones
             else "map_insertion_object_bootstrap_candidate" if map_insertion_mode and "characters_completed" in milestones
             else "initial_post_load_packets_candidate" if initial_packets_mode and "characters_completed" in milestones
             else "character_selection_candidate" if selection_mode and "characters_completed" in milestones
@@ -1996,6 +2014,7 @@ def sanitized_evidence(
         "map_insertion_marker_count": map_insertion_marker_count_value if map_insertion_mode else None,
         "in_world_control_packet_prefix": in_world_control_prefix_value if in_world_control_mode else None,
         "in_world_control_marker_count": in_world_control_marker_count_value if in_world_control_mode else None,
+        "movement_heartbeat_count": movement_heartbeat_count_value if basic_movement_mode else None,
         "post_marker_hold_seconds": (
             generation.get("post_marker_hold_seconds", 0) if generation["mode"] in POST_MARKER_MODES else None
         ),
@@ -2037,7 +2056,8 @@ def verify(args: argparse.Namespace) -> None:
     selection_mode = generation["mode"] == CHARACTER_SELECTION_MODE
     initial_packets_mode = generation["mode"] == INITIAL_POST_LOAD_PACKETS_MODE
     map_insertion_mode = generation["mode"] == MAP_INSERTION_MODE
-    in_world_control_mode = generation["mode"] == IN_WORLD_CONTROL_MODE
+    basic_movement_mode = generation["mode"] == BASIC_MOVEMENT_MODE
+    in_world_control_mode = generation["mode"] in {IN_WORLD_CONTROL_MODE, BASIC_MOVEMENT_MODE}
     login_mode = selection_mode or initial_packets_mode or map_insertion_mode or in_world_control_mode
     rows = character_row_count(manifest, generation) if character_mode else None
     realm_count = realm_character_count(manifest, generation) if populated_mode else None
@@ -2073,6 +2093,7 @@ def verify(args: argparse.Namespace) -> None:
         in_world_control_marker_count_value=(
             in_world_control_marker_count(generation) if in_world_control_mode else None
         ),
+        movement_heartbeat_count_value=movement_heartbeat_count(generation) if basic_movement_mode else None,
     )
     unchanged = protected_inputs_unchanged(manifest, generation)
     generation["isolation_unchanged"] = unchanged
@@ -2125,9 +2146,12 @@ def verify(args: argparse.Namespace) -> None:
                 and evidence["post_marker_hold_seconds"] >= 5
                 and evidence["post_marker_snapshots"] == 2
             )
+        if basic_movement_mode:
+            character_ok = character_ok and evidence["movement_heartbeat_count"] > 0
         if character_ok:
             evidence["outcome"] = (
-                "in_world_control_bootstrap_pass" if in_world_control_mode
+                "basic_movement_pass" if basic_movement_mode
+                else "in_world_control_bootstrap_pass" if in_world_control_mode
                 else "map_insertion_object_bootstrap_pass" if map_insertion_mode
                 else "initial_post_load_packets_pass" if initial_packets_mode
                 else "character_selection_pass" if selection_mode
@@ -2329,6 +2353,7 @@ def comparison_projection(evidence: dict[str, object]) -> dict[str, object]:
             "C->S:CMSG_TIME_SYNC_RESP" in (evidence.get("in_world_control_packet_prefix") or [])
         ),
         "in_world_control_marker_count": evidence.get("in_world_control_marker_count"),
+        "movement_heartbeat_observed": (evidence.get("movement_heartbeat_count") or 0) > 0,
         "post_marker_hold_seconds": evidence.get("post_marker_hold_seconds"),
         "post_marker_snapshots": evidence.get("post_marker_snapshots"),
         "stability_seconds": evidence.get("stability_seconds"),
@@ -2620,6 +2645,21 @@ four Completed: COP_GET_CHARACTERS result=TRUE
         assert enumerated_characters(enum_generation) == [{
             "account_id": ACCOUNT_ID, "guid_low": CHARACTER_GUID, "list_position": CHARACTER_LIST_POSITION,
         }]
+        assert plan_number(BASIC_MOVEMENT_MODE) == "15"
+        for log, expected in (
+            (MOVEMENT_HEARTBEAT_MARKER, 0),
+            (IN_WORLD_CONTROL_MARKER + "\n" + MOVEMENT_HEARTBEAT_MARKER, 0),
+            ("Finished object update bootstrap after adding to map\n" + MOVEMENT_HEARTBEAT_MARKER +
+             "\n" + IN_WORLD_CONTROL_MARKER, 0),
+            ("Finished object update bootstrap after adding to map\n" + IN_WORLD_CONTROL_MARKER +
+             "\n" + MOVEMENT_HEARTBEAT_MARKER, 1),
+        ):
+            (raw / "WorldServer.log").write_text(log)
+            assert movement_heartbeat_count(enum_generation) == expected
+        movement_evidence = {**accepted_control_evidence, "mode": BASIC_MOVEMENT_MODE, "movement_heartbeat_count": 1}
+        projection = comparison_projection(movement_evidence)
+        assert projection == comparison_projection({**movement_evidence, "movement_heartbeat_count": 2})
+        assert projection != comparison_projection({**movement_evidence, "movement_heartbeat_count": 0})
     auth_keys = (
         "RealmServerPort", "BindIP", "LogsDir", "PidFile", "RealmsStateUpdateDelay",
         "LoginDatabaseInfo", "Updates.EnableDatabases", "Updates.AutoSetup", "StrictVersionCheck",
@@ -2653,7 +2693,7 @@ four Completed: COP_GET_CHARACTERS result=TRUE
         pass
     else:
         raise AssertionError("invalid state transition was accepted")
-    print("Plan 7-13 runner self-check passed")
+    print("Real-client runner self-check passed")
 
 
 def stability_seconds(value: str) -> int:
@@ -2686,7 +2726,7 @@ def parser() -> argparse.ArgumentParser:
     prepare_parser.add_argument(
         "--mode", choices=(
             "no-login", "authentication", "character-screen", POPULATED_MODE, CHARACTER_SELECTION_MODE,
-            INITIAL_POST_LOAD_PACKETS_MODE, MAP_INSERTION_MODE, IN_WORLD_CONTROL_MODE,
+            INITIAL_POST_LOAD_PACKETS_MODE, MAP_INSERTION_MODE, IN_WORLD_CONTROL_MODE, BASIC_MOVEMENT_MODE,
         ), default="authentication",
     )
     prepare_parser.add_argument("--minimum-free-gib", type=int, default=25)

--- a/plan/15-basic-movement-packet-contract.md
+++ b/plan/15-basic-movement-packet-contract.md
@@ -2,8 +2,5 @@
 
 Canonical issue: [#33](https://github.com/trolloks/azerothcore-cata/issues/33)
 
-Status: blocked by #27 (Plan 13) and #32 (Plan 14). Opens the "Movement" plan family: proves the
-client's first self-initiated movement-related packet round-trips correctly once idle in the world,
-without AzerothCore's movement validation rejecting or kicking the session. `MovementInfo`'s wire
-layout and the correct opcode must be derived from the pinned Cataclysm reference before
-implementation; nothing about the current WotLK-shaped reader/writer is assumed compatible.
+Status: in progress. The dependency proofs are complete. The canonical issue defines the idle
+`MSG_MOVE_HEARTBEAT` contract, its Cata packet layouts, and local checks before final client acceptance.

--- a/src/server/game/Entities/Object/Object.cpp
+++ b/src/server/game/Entities/Object/Object.cpp
@@ -16,6 +16,7 @@
  */
 
 #include "Object.h"
+#include "MovementPackets.h"
 #include "Battlefield.h"
 #include "BattlefieldMgr.h"
 #include "CellImpl.h"
@@ -370,8 +371,9 @@ void Object::BuildMovementUpdate(ByteBuffer* data, CreateObjectBits flags) const
     if (flags.MovementUpdate)
     {
         self = ToUnit();
-        movementFlags = self->m_movementInfo.GetMovementFlags();
-        movementFlagsExtra = self->m_movementInfo.GetExtraMovementFlags();
+        movementFlags = WorldPackets::Movement::MovementFlagsToClient(self->m_movementInfo.GetMovementFlags());
+        movementFlagsExtra = WorldPackets::Movement::ExtraMovementFlagsToClient(
+            self->m_movementInfo.GetExtraMovementFlags()) & 0x0FFF;
 
         hasTransportTime2 = !self->m_movementInfo.transport.guid.IsEmpty() && self->m_movementInfo.transport.time2 != 0;
         hasPitch = self->HasUnitMovementFlag(MOVEMENTFLAG_SWIMMING | MOVEMENTFLAG_FLYING) || self->HasExtraUnitMovementFlag(MOVEMENTFLAG2_ALWAYS_ALLOW_PITCHING);

--- a/src/server/game/Entities/Object/Object.h
+++ b/src/server/game/Entities/Object/Object.h
@@ -329,6 +329,7 @@ struct MovementInfo
             seat = -1;
             time = 0;
             time2 = 0;
+            vehicleId = 0;
         }
 
         ObjectGuid guid;
@@ -336,6 +337,7 @@ struct MovementInfo
         int8 seat;
         uint32 time;
         uint32 time2;
+        uint32 vehicleId;
     } transport;
 
     // swimming/flying

--- a/src/server/game/Entities/Unit/UnitDefines.h
+++ b/src/server/game/Entities/Unit/UnitDefines.h
@@ -400,6 +400,7 @@ enum MovementFlags
     MOVEMENTFLAG_WATERWALKING               = 0x10000000,       // prevent unit from falling through water
     MOVEMENTFLAG_FALLING_SLOW               = 0x20000000,       // active rogue safe fall spell (passive)
     MOVEMENTFLAG_HOVER                      = 0x40000000,       // hover, cannot jump
+    MOVEMENTFLAG_DISABLE_COLLISION          = 0x80000000,
 
     /// @todo: Check if PITCH_UP and PITCH_DOWN really belong here..
     MOVEMENTFLAG_MASK_MOVING =

--- a/src/server/game/Handlers/MovementHandler.cpp
+++ b/src/server/game/Handlers/MovementHandler.cpp
@@ -377,8 +377,12 @@ void WorldSession::HandleMovementOpcodes(WorldPacket& recvData)
     }
 
     /* extract packet */
-    ObjectGuid guid;
-    recvData >> guid.ReadAsPacked();
+    MovementInfo movementInfo;
+    if (opcode == MSG_MOVE_HEARTBEAT)
+        ReadMovementInfo(recvData, &movementInfo);
+    else
+        recvData >> movementInfo.guid.ReadAsPacked();
+    ObjectGuid guid = movementInfo.guid;
 
     // prevent tampered movement data
     if (!guid || guid != mover->GetGUID())
@@ -394,9 +398,8 @@ void WorldSession::HandleMovementOpcodes(WorldPacket& recvData)
         return;
     }
 
-    MovementInfo movementInfo;
-    movementInfo.guid = guid;
-    ReadMovementInfo(recvData, &movementInfo);
+    if (opcode != MSG_MOVE_HEARTBEAT)
+        ReadMovementInfo(recvData, &movementInfo);
 
     if (!ProcessMovementInfo(movementInfo, mover, plrMover, recvData))
     {
@@ -408,9 +411,11 @@ void WorldSession::HandleMovementOpcodes(WorldPacket& recvData)
         return;
 
     /* process position-change */
-    WorldPacket data(opcode, recvData.size());
+    WorldPacket data(opcode == MSG_MOVE_HEARTBEAT ? uint16(SMSG_MOVE_UPDATE) : opcode, recvData.size());
     WriteMovementInfo(&data, &movementInfo);
     mover->SendMessageToSet(&data, _player);
+    if (opcode == MSG_MOVE_HEARTBEAT)
+        LOG_DEBUG("network", "Accepted Cataclysm movement heartbeat after movement validation");
 }
 
 void WorldSession::SynchronizeMovement(MovementInfo& movementInfo)

--- a/src/server/game/Server/Packets/MovementPackets.cpp
+++ b/src/server/game/Server/Packets/MovementPackets.cpp
@@ -6,6 +6,198 @@
  */
 
 #include "MovementPackets.h"
+#include "Object.h"
+#include <G3D/Vector3.h>
+
+uint32 WorldPackets::Movement::MovementFlagsToClient(uint32 flags)
+{
+    // AC keeps its internal flag positions. Cata moved transport and spline presence out of this field.
+    return (flags & 0x000001FF) | ((flags & 0x07FFFC00) >> 1) | ((flags & 0xF0000000) >> 2);
+}
+
+uint16 WorldPackets::Movement::ExtraMovementFlagsToClient(uint16 flags)
+{
+    return (flags & 0x03C3) | ((flags & 0x0038) >> 1) | ((flags & 0x0004) << 3) |
+        ((flags & 0x1C00) << 3) | ((flags & 0xE000) >> 3);
+}
+
+void WorldPackets::Movement::ReadHeartbeat(WorldPacket& packet, MovementInfo& info)
+{
+    info = MovementInfo();
+    packet >> info.pos.m_positionZ >> info.pos.m_positionX >> info.pos.m_positionY;
+    bool hasPitch = !packet.ReadBit();
+    bool hasTimestamp = !packet.ReadBit();
+    bool hasFallData = packet.ReadBit();
+    bool hasFlags2 = !packet.ReadBit();
+    bool hasTransport = packet.ReadBit();
+    for (uint8 index : { 7, 1, 0, 4, 2 })
+        info.guid[index] = packet.ReadBit();
+    bool hasOrientation = !packet.ReadBit();
+    info.guid[5] = packet.ReadBit();
+    info.guid[3] = packet.ReadBit();
+    bool hasSplineElevation = !packet.ReadBit();
+    bool hasSpline = packet.ReadBit();
+    packet.ReadBit();
+    info.guid[6] = packet.ReadBit();
+    bool hasFlags = !packet.ReadBit();
+    bool hasVehicleId = false;
+    bool hasTransportTime2 = false;
+    if (hasTransport)
+    {
+        hasVehicleId = packet.ReadBit();
+        info.transport.guid[4] = packet.ReadBit();
+        info.transport.guid[2] = packet.ReadBit();
+        hasTransportTime2 = packet.ReadBit();
+        for (uint8 index : { 5, 7, 6, 0, 3, 1 })
+            info.transport.guid[index] = packet.ReadBit();
+    }
+    bool hasFallDirection = hasFallData && packet.ReadBit();
+    if (hasFlags)
+    {
+        uint32 flags = packet.ReadBits(30);
+        info.flags = (flags & 0x000001FF) | ((flags & 0x03FFFE00) << 1) | ((flags & 0x3C000000) << 2);
+    }
+    if (hasFlags2)
+    {
+        uint16 flags = packet.ReadBits(12);
+        info.flags2 = (flags & 0x03C3) | ((flags & 0x001C) << 1) | ((flags & 0x0020) >> 3) |
+            ((flags & 0xE000) >> 3) | ((flags & 0x1C00) << 3);
+    }
+    if (hasTransport)
+        info.AddMovementFlag(MOVEMENTFLAG_ONTRANSPORT);
+    if (hasSpline)
+        info.AddMovementFlag(MOVEMENTFLAG_SPLINE_ENABLED);
+    if (hasTransportTime2)
+        info.AddExtraMovementFlag(MOVEMENTFLAG2_INTERPOLATED_MOVEMENT);
+    for (uint8 index : { 3, 6, 1, 7, 2, 5, 0, 4 })
+        packet.ReadByteSeq(info.guid[index]);
+    if (hasTransport)
+    {
+        packet >> info.transport.pos.m_positionZ >> info.transport.seat;
+        info.transport.pos.SetOrientation(packet.read<float>());
+        packet.ReadByteSeq(info.transport.guid[4]);
+        packet >> info.transport.pos.m_positionY >> info.transport.time >> info.transport.pos.m_positionX;
+        for (uint8 index : { 5, 1, 3, 7 })
+            packet.ReadByteSeq(info.transport.guid[index]);
+        if (hasVehicleId)
+            packet >> info.transport.vehicleId;
+        if (hasTransportTime2)
+            packet >> info.transport.time2;
+        for (uint8 index : { 2, 0, 6 })
+            packet.ReadByteSeq(info.transport.guid[index]);
+    }
+    if (hasOrientation)
+        info.pos.SetOrientation(packet.read<float>());
+    if (hasFallData)
+    {
+        packet >> info.jump.zspeed >> info.fallTime;
+        if (hasFallDirection)
+            packet >> info.jump.xyspeed >> info.jump.cosAngle >> info.jump.sinAngle;
+    }
+    if (hasPitch)
+        info.pitch = G3D::wrap(packet.read<float>(), float(-M_PI), float(M_PI));
+    if (hasSplineElevation)
+        packet >> info.splineElevation;
+    if (hasTimestamp)
+        packet >> info.time;
+    if (packet.rpos() != packet.size())
+        throw ByteBufferInvalidValueException("heartbeat payload", "trailing bytes");
+}
+
+void WorldPackets::Movement::WriteMovementUpdate(WorldPacket& packet, MovementInfo const& info)
+{
+    uint32 flags = MovementFlagsToClient(info.flags);
+    uint16 flags2 = ExtraMovementFlagsToClient(info.flags2) & 0x0FFF;
+    bool hasFallDirection = info.HasMovementFlag(MOVEMENTFLAG_FALLING);
+    bool hasFallData = hasFallDirection || info.fallTime != 0;
+    bool hasOrientation = !G3D::fuzzyEq(info.pos.GetOrientation(), 0.0f);
+    bool hasTransport = !info.transport.guid.IsEmpty();
+    bool hasVehicleId = hasTransport && info.transport.vehicleId != 0;
+    bool hasTransportTime2 = hasTransport && info.transport.time2 != 0;
+    bool hasPitch = info.HasMovementFlag(MOVEMENTFLAG_SWIMMING | MOVEMENTFLAG_FLYING) ||
+        info.HasExtraMovementFlag(MOVEMENTFLAG2_ALWAYS_ALLOW_PITCHING);
+    bool hasSplineElevation = info.HasMovementFlag(MOVEMENTFLAG_SPLINE_ELEVATION);
+    ObjectGuid const& guid = info.guid;
+    ObjectGuid const& transport = info.transport.guid;
+
+    packet.WriteBit(hasFallData);
+    packet.WriteBit(guid[3]);
+    packet.WriteBit(guid[6]);
+    packet.WriteBit(!flags2);
+    packet.WriteBit(info.HasMovementFlag(MOVEMENTFLAG_SPLINE_ENABLED));
+    packet.WriteBit(false); // Timestamp is always present in server movement updates.
+    packet.WriteBit(guid[0]);
+    packet.WriteBit(guid[1]);
+    if (flags2)
+        packet.WriteBits(flags2, 12);
+    packet.WriteBit(guid[7]);
+    packet.WriteBit(!flags);
+    packet.WriteBit(!hasOrientation);
+    packet.WriteBit(guid[2]);
+    packet.WriteBit(!hasSplineElevation);
+    packet.WriteBit(false); // Height change failed.
+    packet.WriteBit(guid[4]);
+    if (hasFallData)
+        packet.WriteBit(hasFallDirection);
+    packet.WriteBit(guid[5]);
+    packet.WriteBit(hasTransport);
+    if (flags)
+        packet.WriteBits(flags, 30);
+    if (hasTransport)
+    {
+        packet.WriteBit(transport[3]);
+        packet.WriteBit(hasVehicleId);
+        for (uint8 index : { 6, 1, 7, 0, 4 })
+            packet.WriteBit(transport[index]);
+        packet.WriteBit(hasTransportTime2);
+        packet.WriteBit(transport[5]);
+        packet.WriteBit(transport[2]);
+    }
+    packet.WriteBit(!hasPitch);
+    packet.FlushBits();
+    packet.WriteByteSeq(guid[5]);
+    if (hasFallData)
+    {
+        if (hasFallDirection)
+            packet << info.jump.xyspeed << info.jump.sinAngle << info.jump.cosAngle;
+        packet << info.jump.zspeed << info.fallTime;
+    }
+    if (hasSplineElevation)
+        packet << info.splineElevation;
+    packet.WriteByteSeq(guid[7]);
+    packet << info.pos.GetPositionY();
+    packet.WriteByteSeq(guid[3]);
+    if (hasTransport)
+    {
+        if (hasVehicleId)
+            packet << info.transport.vehicleId;
+        packet.WriteByteSeq(transport[6]);
+        packet << info.transport.seat;
+        packet.WriteByteSeq(transport[5]);
+        packet << info.transport.pos.GetPositionX();
+        packet.WriteByteSeq(transport[1]);
+        packet << info.transport.pos.GetOrientation();
+        packet.WriteByteSeq(transport[2]);
+        if (hasTransportTime2)
+            packet << info.transport.time2;
+        packet.WriteByteSeq(transport[0]);
+        packet << info.transport.pos.GetPositionZ();
+        for (uint8 index : { 7, 4, 3 })
+            packet.WriteByteSeq(transport[index]);
+        packet << info.transport.pos.GetPositionY() << info.transport.time;
+    }
+    packet.WriteByteSeq(guid[4]);
+    packet << info.pos.GetPositionX();
+    packet.WriteByteSeq(guid[6]);
+    packet << info.pos.GetPositionZ() << info.time;
+    packet.WriteByteSeq(guid[2]);
+    if (hasPitch)
+        packet << info.pitch;
+    packet.WriteByteSeq(guid[0]);
+    if (hasOrientation)
+        packet << info.pos.GetOrientation();
+    packet.WriteByteSeq(guid[1]);
+}
 
 WorldPacket const* WorldPackets::Movement::MoveSetActiveMover::Write()
 {

--- a/src/server/game/Server/Packets/MovementPackets.h
+++ b/src/server/game/Server/Packets/MovementPackets.h
@@ -11,10 +11,17 @@
 #include "ObjectGuid.h"
 #include "Packet.h"
 
+struct MovementInfo;
+
 namespace WorldPackets
 {
     namespace Movement
     {
+        uint32 MovementFlagsToClient(uint32 flags);
+        uint16 ExtraMovementFlagsToClient(uint16 flags);
+        void ReadHeartbeat(WorldPacket& packet, MovementInfo& info);
+        void WriteMovementUpdate(WorldPacket& packet, MovementInfo const& info);
+
         class MoveSetActiveMover final : public ServerPacket
         {
         public:

--- a/src/server/game/Server/Protocol/Opcodes.cpp
+++ b/src/server/game/Server/Protocol/Opcodes.cpp
@@ -760,6 +760,7 @@ void OpcodeTable::Initialize()
     /*0x0223*/ DEFINE_HANDLER(CMSG_CHARACTER_POINT_CHEAT,                                            STATUS_NEVER,      PROCESS_INPLACE,        &WorldSession::Handle_NULL                              );
     /*0x4316*/ DEFINE_SERVER_OPCODE_HANDLER(SMSG_GOSSIP_POI,                                         STATUS_NEVER);
     DEFINE_SERVER_OPCODE_HANDLER(SMSG_MOVE_SET_ACTIVE_MOVER,                                        STATUS_NEVER);
+    DEFINE_SERVER_OPCODE_HANDLER(SMSG_MOVE_UPDATE,                                                  STATUS_NEVER);
     /*0x0D54*/ DEFINE_HANDLER(CMSG_CHAT_IGNORED,                                                     STATUS_LOGGEDIN,   PROCESS_THREADUNSAFE,   &WorldSession::HandleChatIgnoredOpcode                  );
     /*0x0228*/ DEFINE_HANDLER(CMSG_GM_SILENCE,                                                       STATUS_NEVER,      PROCESS_INPLACE,        &WorldSession::Handle_NULL                              );
     /*0x0229*/ DEFINE_HANDLER(CMSG_GM_REVEALTO,                                                      STATUS_NEVER,      PROCESS_INPLACE,        &WorldSession::Handle_NULL                              );

--- a/src/server/game/Server/Protocol/Opcodes.h
+++ b/src/server/game/Server/Protocol/Opcodes.h
@@ -999,6 +999,7 @@ enum OpcodeServer : uint16
     SMSG_SPIRIT_HEALER_CONFIRM                      = 0x4917,
     SMSG_GOSSIP_POI                                 = 0x4316,
     SMSG_MOVE_SET_ACTIVE_MOVER                       = 0x11B3,
+    SMSG_MOVE_UPDATE                                 = 0x79A2,
     SMSG_GM_PLAYER_INFO                             = 0x4A15,
     SMSG_LOGIN_VERIFY_WORLD                         = 0x2005,
     SMSG_LOAD_CUF_PROFILES                          = 0x50B1,

--- a/src/server/game/Server/WorldSession.cpp
+++ b/src/server/game/Server/WorldSession.cpp
@@ -36,6 +36,7 @@
 #include "MapMgr.h"
 #include "Metric.h"
 #include "MiscPackets.h"
+#include "MovementPackets.h"
 #include "ObjectAccessor.h"
 #include "ObjectMgr.h"
 #include "Opcodes.h"
@@ -1076,38 +1077,43 @@ void WorldSession::SaveTutorialsData(CharacterDatabaseTransaction trans)
 
 void WorldSession::ReadMovementInfo(WorldPacket& data, MovementInfo* mi)
 {
-    data >> mi->flags;
-    data >> mi->flags2;
-    data >> mi->time;
-    data >> mi->pos.PositionXYZOStream();
-
-    if (mi->HasMovementFlag(MOVEMENTFLAG_ONTRANSPORT))
+    if (data.GetOpcode() == MSG_MOVE_HEARTBEAT)
+        WorldPackets::Movement::ReadHeartbeat(data, *mi);
+    else
     {
-        data >> mi->transport.guid.ReadAsPacked();
+        data >> mi->flags;
+        data >> mi->flags2;
+        data >> mi->time;
+        data >> mi->pos.PositionXYZOStream();
 
-        data >> mi->transport.pos.PositionXYZOStream();
-        data >> mi->transport.time;
-        data >> mi->transport.seat;
+        if (mi->HasMovementFlag(MOVEMENTFLAG_ONTRANSPORT))
+        {
+            data >> mi->transport.guid.ReadAsPacked();
 
-        if (mi->HasExtraMovementFlag(MOVEMENTFLAG2_INTERPOLATED_MOVEMENT))
-            data >> mi->transport.time2;
+            data >> mi->transport.pos.PositionXYZOStream();
+            data >> mi->transport.time;
+            data >> mi->transport.seat;
+
+            if (mi->HasExtraMovementFlag(MOVEMENTFLAG2_INTERPOLATED_MOVEMENT))
+                data >> mi->transport.time2;
+        }
+
+        if (mi->HasMovementFlag(MovementFlags(MOVEMENTFLAG_SWIMMING | MOVEMENTFLAG_FLYING)) || (mi->HasExtraMovementFlag(MOVEMENTFLAG2_ALWAYS_ALLOW_PITCHING)))
+            data >> mi->pitch;
+
+        data >> mi->fallTime;
+
+        if (mi->HasMovementFlag(MOVEMENTFLAG_FALLING))
+        {
+            data >> mi->jump.zspeed;
+            data >> mi->jump.sinAngle;
+            data >> mi->jump.cosAngle;
+            data >> mi->jump.xyspeed;
+        }
+
+        if (mi->HasMovementFlag(MOVEMENTFLAG_SPLINE_ELEVATION))
+            data >> mi->splineElevation;
     }
-
-    if (mi->HasMovementFlag(MovementFlags(MOVEMENTFLAG_SWIMMING | MOVEMENTFLAG_FLYING)) || (mi->HasExtraMovementFlag(MOVEMENTFLAG2_ALWAYS_ALLOW_PITCHING)))
-        data >> mi->pitch;
-
-    data >> mi->fallTime;
-
-    if (mi->HasMovementFlag(MOVEMENTFLAG_FALLING))
-    {
-        data >> mi->jump.zspeed;
-        data >> mi->jump.sinAngle;
-        data >> mi->jump.cosAngle;
-        data >> mi->jump.xyspeed;
-    }
-
-    if (mi->HasMovementFlag(MOVEMENTFLAG_SPLINE_ELEVATION))
-        data >> mi->splineElevation;
 
     //! Anti-cheat checks. Please keep them in seperate if () blocks to maintain a clear overview.
     //! Might be subject to latency, so just remove improper flags.
@@ -1190,6 +1196,12 @@ void WorldSession::ReadMovementInfo(WorldPacket& data, MovementInfo* mi)
 
 void WorldSession::WriteMovementInfo(WorldPacket* data, MovementInfo* mi)
 {
+    if (data->GetOpcode() == SMSG_MOVE_UPDATE)
+    {
+        WorldPackets::Movement::WriteMovementUpdate(*data, *mi);
+        return;
+    }
+
     *data << mi->guid.WriteAsPacked();
 
     *data << mi->flags;

--- a/src/test/server/game/Server/Packets/MovementPacketsTest.cpp
+++ b/src/test/server/game/Server/Packets/MovementPacketsTest.cpp
@@ -1,0 +1,135 @@
+/*
+ * This file is part of the AzerothCore Project. See AUTHORS file for Copyright information
+ *
+ * You may redistribute it and/or modify it under the terms of the GNU General Public License
+ * version 2 or, at your option, any later version.
+ */
+
+#include "MovementPackets.h"
+#include "Object.h"
+#include "Util.h"
+#include <gtest/gtest.h>
+#include <span>
+
+namespace
+{
+    // Synthetic fixtures from apps/cata/generate_movement_fixtures.py and its pinned reference sequences.
+    std::string const Idle = "000040400000803F00000040936C400002030504030201";
+    std::string const Sparse = "00004040000080BF00000040D124C01100";
+    std::string const OptionalFields =
+        "000070400000A03F000020C02FD8BFF84001000020050603090207000400000CC1FF00000040410000F0402A000000"
+        "0000C840317151112C0000002B0000006181210000C03F000088C04D0000000000B0400000403F000000BF000080BE"
+        "0000803E44332211";
+
+    WorldPacket Heartbeat(std::string const& hex)
+    {
+        std::vector<uint8> bytes(hex.size() / 2);
+        Acore::Impl::HexStrToByteArray(hex, bytes.data(), bytes.size());
+        WorldPacket packet(MSG_MOVE_HEARTBEAT, bytes.size());
+        if (!bytes.empty())
+            packet.append(bytes.data(), bytes.size());
+        return packet;
+    }
+
+    std::string MovementUpdate(MovementInfo const& info)
+    {
+        WorldPacket packet(SMSG_MOVE_UPDATE);
+        WorldPackets::Movement::WriteMovementUpdate(packet, info);
+        return ByteArrayToHexStr(std::span<uint8 const>(packet.contents(), packet.size()));
+    }
+}
+
+TEST(MovementPacketsTest, ReadsIdleHeartbeatAndWritesMovementUpdate)
+{
+    WorldPacket packet = Heartbeat(Idle);
+    MovementInfo info;
+    WorldPackets::Movement::ReadHeartbeat(packet, info);
+    EXPECT_EQ(info.guid, ObjectGuid(uint64(0x01020304)));
+    EXPECT_EQ(info.flags, 0u);
+    EXPECT_EQ(info.flags2, 0u);
+    EXPECT_FLOAT_EQ(info.pos.GetPositionX(), 1.0f);
+    EXPECT_FLOAT_EQ(info.pos.GetPositionY(), 2.0f);
+    EXPECT_FLOAT_EQ(info.pos.GetPositionZ(), 3.0f);
+    EXPECT_EQ(info.time, 0x01020304u);
+    EXPECT_EQ(packet.rpos(), packet.size());
+    EXPECT_EQ(MovementUpdate(info), "53784000000040000000803F0000404004030201030502");
+
+    packet = Heartbeat(Sparse);
+    WorldPackets::Movement::ReadHeartbeat(packet, info);
+    EXPECT_EQ(info.guid, ObjectGuid(uint64(0x0010000000000001)));
+    EXPECT_EQ(info.time, 0u);
+    EXPECT_FLOAT_EQ(info.pos.GetOrientation(), 0.0f);
+    EXPECT_EQ(MovementUpdate(info), "32684000000040000080BF11000040400000000000");
+}
+
+TEST(MovementPacketsTest, ReadsOptionalFieldsAndPreservesTheirWireLayout)
+{
+    WorldPacket packet = Heartbeat(OptionalFields);
+    MovementInfo info;
+    WorldPackets::Movement::ReadHeartbeat(packet, info);
+    EXPECT_EQ(info.guid, ObjectGuid(uint64(0x0807060504030201)));
+    EXPECT_EQ(info.flags, uint32(MOVEMENTFLAG_FALLING | MOVEMENTFLAG_SPLINE_ELEVATION | MOVEMENTFLAG_ONTRANSPORT));
+    EXPECT_EQ(info.flags2, MOVEMENTFLAG2_ALWAYS_ALLOW_PITCHING | MOVEMENTFLAG2_INTERPOLATED_MOVEMENT);
+    EXPECT_FLOAT_EQ(info.pos.GetPositionX(), 1.25f);
+    EXPECT_FLOAT_EQ(info.pos.GetPositionY(), -2.5f);
+    EXPECT_FLOAT_EQ(info.pos.GetPositionZ(), 3.75f);
+    EXPECT_FLOAT_EQ(info.pos.GetOrientation(), 1.5f);
+    EXPECT_EQ(info.time, 0x11223344u);
+    EXPECT_EQ(info.transport.guid, ObjectGuid(uint64(0x1020304050607080)));
+    EXPECT_FLOAT_EQ(info.transport.pos.GetPositionX(), 6.25f);
+    EXPECT_FLOAT_EQ(info.transport.pos.GetPositionY(), 7.5f);
+    EXPECT_FLOAT_EQ(info.transport.pos.GetPositionZ(), -8.75f);
+    EXPECT_FLOAT_EQ(info.transport.pos.GetOrientation(), 2.0f);
+    EXPECT_EQ(info.transport.seat, -1);
+    EXPECT_EQ(info.transport.time, 42u);
+    EXPECT_EQ(info.transport.time2, 43u);
+    EXPECT_EQ(info.transport.vehicleId, 44u);
+    EXPECT_EQ(info.fallTime, 77u);
+    EXPECT_FLOAT_EQ(info.jump.zspeed, -4.25f);
+    EXPECT_FLOAT_EQ(info.jump.xyspeed, 5.5f);
+    EXPECT_FLOAT_EQ(info.jump.cosAngle, 0.75f);
+    EXPECT_FLOAT_EQ(info.jump.sinAngle, -0.5f);
+    EXPECT_FLOAT_EQ(info.pitch, -0.25f);
+    EXPECT_FLOAT_EQ(info.splineElevation, 0.25f);
+    EXPECT_EQ(MovementUpdate(info),
+        "E301093C2000800FFC070000B040000000BF0000403F000088C04D0000000000803E09000020C0052C00000021FF31"
+        "0000C8407100000040612B0000008100000CC11141510000F0402A000000040000A03F060000704044332211020000"
+        "80BE000000C03F03");
+}
+
+TEST(MovementPacketsTest, RejectsTruncatedAndTrailingHeartbeatData)
+{
+    for (std::string const& fixture : { Idle, Sparse, OptionalFields })
+    {
+        for (std::size_t length = 0; length < fixture.size(); length += 2)
+        {
+            WorldPacket packet = Heartbeat(fixture.substr(0, length));
+            MovementInfo info;
+            EXPECT_THROW(WorldPackets::Movement::ReadHeartbeat(packet, info), ByteBufferException) << length;
+        }
+        WorldPacket packet = Heartbeat(fixture + "00");
+        MovementInfo info;
+        EXPECT_THROW(WorldPackets::Movement::ReadHeartbeat(packet, info), ByteBufferInvalidValueException);
+    }
+}
+
+TEST(MovementPacketsTest, TranslatesInternalFlagsAtTheWireBoundary)
+{
+    using namespace WorldPackets::Movement;
+    EXPECT_EQ(MovementFlagsToClient(MOVEMENTFLAG_WALKING), 0x100u);
+    EXPECT_EQ(MovementFlagsToClient(MOVEMENTFLAG_DISABLE_GRAVITY), 0x200u);
+    EXPECT_EQ(MovementFlagsToClient(MOVEMENTFLAG_ROOT), 0x400u);
+    EXPECT_EQ(MovementFlagsToClient(MOVEMENTFLAG_FALLING), 0x800u);
+    EXPECT_EQ(MovementFlagsToClient(MOVEMENTFLAG_SWIMMING), 0x100000u);
+    EXPECT_EQ(MovementFlagsToClient(MOVEMENTFLAG_FLYING), 0x1000000u);
+    EXPECT_EQ(MovementFlagsToClient(MOVEMENTFLAG_SPLINE_ELEVATION), 0x2000000u);
+    EXPECT_EQ(MovementFlagsToClient(MOVEMENTFLAG_WATERWALKING), 0x4000000u);
+    EXPECT_EQ(MovementFlagsToClient(MOVEMENTFLAG_FALLING_SLOW), 0x8000000u);
+    EXPECT_EQ(MovementFlagsToClient(MOVEMENTFLAG_HOVER), 0x10000000u);
+    EXPECT_EQ(MovementFlagsToClient(MOVEMENTFLAG_DISABLE_COLLISION), 0x20000000u);
+    EXPECT_EQ(MovementFlagsToClient(MOVEMENTFLAG_ONTRANSPORT | MOVEMENTFLAG_SPLINE_ENABLED), 0u);
+    EXPECT_EQ(ExtraMovementFlagsToClient(MOVEMENTFLAG2_FULL_SPEED_TURNING), 0x4u);
+    EXPECT_EQ(ExtraMovementFlagsToClient(MOVEMENTFLAG2_FULL_SPEED_PITCHING), 0x8u);
+    EXPECT_EQ(ExtraMovementFlagsToClient(MOVEMENTFLAG2_ALWAYS_ALLOW_PITCHING), 0x10u);
+    EXPECT_EQ(ExtraMovementFlagsToClient(MOVEMENTFLAG2_INTERPOLATED_MOVEMENT), 0x2000u);
+}


### PR DESCRIPTION
## Changes Proposed:

Idle Cata heartbeats were being read as WotLK packets and rejected before movement processing. Decode their bit-packed fields and GUID, retain AC's movement validation, and broadcast the Cata `SMSG_MOVE_UPDATE` layout. Translate movement flags at the wire boundary, including object creation.

- [x] Core (units, players, creatures, game systems).
- [ ] Scripts (bosses, spell scripts, creature scripts).
- [ ] Database (SAI, creatures, etc).

### AI-assisted Pull Requests

- [x] AI tools were used entirely or partially to prepare this pull request.
  - Codex, GPT-6: implementation, synthetic fixtures, validation, review, and PR description.
- [x] I have read and understood the [AC guidelines for AI Agentic Engineering](https://www.azerothcore.org/wiki/agentic-engineering).

## Issues Addressed:

Closes #33.

## SOURCE:

- [ ] Live research on official servers.
- [ ] Sniffs.
- [ ] Video evidence, knowledge databases or other public sources.
- [x] Adapted from another project, with upstream authors credited in the commit.

[TrinityCore's pinned Cata movement sequences](https://github.com/TrinityCore/TrinityCore/blob/c699217775d90794158422387b07a917e161b582/src/server/game/Movement/MovementStructures.cpp), plus its player reader and unit writer. Shauren is the commit author; Ovahlord, Spp, and ariel- are credited as co-authors.

## Tests Performed:

- [x] Tested in-game by the author through the owned build-15595 client automation.
- [ ] Tested by other community members or on production servers.
- [x] Optional movement states need further in-game coverage.

Built `worldserver`, `authserver`, and `unit_tests` on Linux. All 11 focused packet/opcode tests passed, including four movement tests. The full suite passed 5,945 tests, skipped 5,487, and had one disabled test, with no failures. The client runner self-check and focus checks passed.

Real-client acceptance used commit `aaf522275b6fdf991a1a97bc87a5c4f78f5d5c2d`:

| Fresh generation | Accepted heartbeats | Time-sync requests/responses | Stable hold | Visual, isolation, reset |
| --- | --- | --- | --- | --- |
| 82 | 1 | 4 / 4 | 30 seconds | PASS |
| 83 | 1 | 4 / 4 | 30 seconds | PASS |

Both clients visibly entered Northshire. The semantic comparison passed. The source client and personal Bottle remained unchanged, and both recorded containers and volumes were removed. No client retries were needed.

`git diff --check` and SQL style passed. C++ style reported the three existing blank-line findings listed below.

## How to Test the Changes:

- [x] This pull request can be tested by following the reproduction steps provided in the linked issue.
- [x] Further testing of optional movement states is useful.

1. Run `unit_tests --gtest_filter=MovementPacketsTest.*` for the synthetic heartbeat and movement-update fixtures.
2. Run `python3 apps/cata/run_real_client_authentication.py self-check`.
3. Use the isolated client invocation in `plan/client-automation.md` with `--mode basic-movement`. Let the character idle after world entry. Require a successfully processed heartbeat, a stable hold, visual confirmation, unchanged protected inputs, and an owned reset.

## Known Issues and TODO List:

- This proves idle heartbeat acceptance. Directional movement, jump/land, speed acknowledgements, and other units' splines remain separate work.
- No second observer was connected; the outgoing movement-update layout was checked against synthetic reference vectors.
- The existing time-skipped handler still reports a wrong GUID for its unconverted packet layout.
- Optional transport, pitch, and falling fields have synthetic coverage; they still need in-game coverage as those movement paths are converted.

## Self-review

No new findings at `aaf522275b6fdf991a1a97bc87a5c4f78f5d5c2d`.

Existing C++ style findings: multiple blank lines in `src/server/game/Entities/Object/Updates/UpdateFields.h` at lines 40, 186, and 522. That file is unchanged by this PR.

## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
