### PR TITLE
fix(Core): Convert Cata run-speed acknowledgements

### DIFF
--- a/.agents/docs/build.md
+++ b/.agents/docs/build.md
@@ -2,6 +2,11 @@
 
 Out-of-source build is required (in-source is blocked).
 
+Build only when explicitly authorized. Once authorized, build the required targets once and reuse
+those binaries for tests and client acceptance. Rebuild only when relevant inputs changed or a build
+failed; a second client run or `prepare` is not itself a reason to rebuild. Do not compile the WoW
+client; the acceptance harness uses the existing build-15595 executable.
+
 ```bash
 mkdir -p build && cd build
 cmake .. -DCMAKE_INSTALL_PREFIX=$HOME/azeroth-server -DCMAKE_BUILD_TYPE=RelWithDebInfo \

--- a/apps/cata/generate_movement_fixtures.py
+++ b/apps/cata/generate_movement_fixtures.py
@@ -10,7 +10,7 @@ import subprocess
 PIN = "c699217775d90794158422387b07a917e161b582"
 
 
-def encode(sequence, sample):
+def encode(sequence, sample, always_timestamp=False):
     output = bytearray()
     bits = []
 
@@ -36,7 +36,7 @@ def encode(sequence, sample):
         "FallDirection": bool(sample.get("MovementFlags", 0) & 0x800),
         "Spline": False, "HeightChangeFailed": False,
     })
-    if sequence[0] == "MSEHasFallData":
+    if always_timestamp:
         conditions["Timestamp"] = True
     for element in sequence:
         name = element.removeprefix("MSE")
@@ -83,7 +83,7 @@ def encode(sequence, sample):
                 if name in {"FallHorizontalSpeed", "FallCosAngle", "FallSinAngle"} and not conditions["FallDirection"]:
                     continue
             format_code = "f"
-            if name in {"Timestamp", "FallTime", "TransportTime", "TransportTime2", "TransportVehicleId"}:
+            if name in {"Counter", "Timestamp", "FallTime", "TransportTime", "TransportTime2", "TransportVehicleId"}:
                 format_code = "I"
             elif name == "TransportSeat":
                 format_code = "b"
@@ -101,7 +101,10 @@ def main():
         "git", "-C", args.trinity_repo, "show", PIN + ":src/server/game/Movement/MovementStructures.cpp",
     ], text=True)
     sequences = {}
-    for name in ("MovementHeartBeat", "MovementUpdate"):
+    for name in (
+        "MovementHeartBeat", "MovementUpdate", "MoveSetRunSpeed", "MovementForceRunSpeedChangeAck",
+        "MovementUpdateRunSpeed",
+    ):
         body = re.search(r"\b" + name + r"\[\]\s*=\s*\{(.*?)\};", source, re.S).group(1)
         sequences[name] = re.findall(r"\bMSE\w+", body)
     samples = {
@@ -117,7 +120,10 @@ def main():
             "FallCosAngle": 0.75, "FallSinAngle": -0.5, "Pitch": -0.25, "SplineElevation": 0.25,
         },
     }
-    print(json.dumps({name: {packet: encode(sequence, sample) for packet, sequence in sequences.items()}
+    for sample in samples.values():
+        sample.update({"Counter": 0x10203040, "ExtraElement": 10.5})
+    print(json.dumps({name: {packet: encode(sequence, sample, packet in {"MovementUpdate", "MovementUpdateRunSpeed"})
+                            for packet, sequence in sequences.items()}
                       for name, sample in samples.items()}, indent=2))
 
 

--- a/apps/cata/run_real_client_authentication.py
+++ b/apps/cata/run_real_client_authentication.py
@@ -13,6 +13,7 @@ import secrets
 import shutil
 import signal
 import socket
+import struct
 import subprocess
 import sys
 import tempfile
@@ -139,9 +140,13 @@ INITIAL_POST_LOAD_PACKETS_MODE = "initial-post-load-packets"
 MAP_INSERTION_MODE = "map-insertion-object-bootstrap"
 IN_WORLD_CONTROL_MODE = "in-world-control-bootstrap"
 BASIC_MOVEMENT_MODE = "basic-movement"
+RUN_SPEED_MODE = "run-speed-change"
+RUN_SPEED_AURA = 2983
+RUN_SPEED_AURA_AMOUNT = 50
+RUN_SPEED_AURA_DURATION_MS = 60000
 POPULATED_CHARACTER_MODES = frozenset({
     POPULATED_MODE, CHARACTER_SELECTION_MODE, INITIAL_POST_LOAD_PACKETS_MODE, MAP_INSERTION_MODE,
-    IN_WORLD_CONTROL_MODE, BASIC_MOVEMENT_MODE,
+    IN_WORLD_CONTROL_MODE, BASIC_MOVEMENT_MODE, RUN_SPEED_MODE,
 })
 CHARACTER_MODES = frozenset({"character-screen", *POPULATED_CHARACTER_MODES})
 CHARACTER_GUID = 0x01020304
@@ -155,6 +160,8 @@ CHARACTER_ZONE = 12
 
 
 def plan_number(mode: str) -> str:
+    if mode == RUN_SPEED_MODE:
+        return "16"
     if mode == BASIC_MOVEMENT_MODE:
         return "15"
     if mode == IN_WORLD_CONTROL_MODE:
@@ -488,6 +495,34 @@ def mysql(
     return run_command(command, input_bytes=payload, timeout=timeout).stdout.decode().rstrip("\n")
 
 
+def verify_run_speed_aura_source(dbc_root: Path) -> None:
+    # These are the current server's flattened Spell.dbc columns, not the client's split Cata tables.
+    data = (dbc_root / "Spell.dbc").read_bytes()
+    magic, count, fields, size, _ = struct.unpack_from("<4s4I", data)
+    if (magic, fields, size) != (b"WDBC", 234, 936):
+        raise RuntimeError("run-speed fixture requires the current 234-field server Spell.dbc")
+    for offset in range(20, 20 + count * size, size):
+        row = struct.unpack_from("<234I", data, offset)
+        if row[0] == RUN_SPEED_AURA:
+            if (row[71], row[95], row[80] + 1) != (6, 31, RUN_SPEED_AURA_AMOUNT):
+                raise RuntimeError("Sprint effect 0 no longer matches the saved run-speed aura fixture")
+            return
+    raise RuntimeError("Sprint is absent from the server Spell.dbc")
+
+
+def run_speed_aura_seed_sql() -> str:
+    # The extended saved duration lets normal aura expiry trigger the handshake after world entry.
+    return (
+        f"DELETE FROM `character_aura` WHERE `guid`={CHARACTER_GUID} AND `spell`={RUN_SPEED_AURA};"
+        "INSERT INTO `character_aura` "
+        "(`guid`,`casterGuid`,`spell`,`effectMask`,`recalculateMask`,`stackCount`,"
+        "`amount0`,`base_amount0`,`maxDuration`,`remainTime`) "
+        f"VALUES ({CHARACTER_GUID},{CHARACTER_GUID},{RUN_SPEED_AURA},1,0,1,"
+        f"{RUN_SPEED_AURA_AMOUNT},{RUN_SPEED_AURA_AMOUNT - 1},"
+        f"{RUN_SPEED_AURA_DURATION_MS},{RUN_SPEED_AURA_DURATION_MS});"
+    )
+
+
 def populated_character_seed_sql() -> str:
     x, y, z = CHARACTER_POSITION
     return (
@@ -792,7 +827,7 @@ def write_configs(manifest: Manifest, generation: Generation) -> None:
         "SOAP.Enabled": "0",
         "Cluster.Enabled": "0",
         "Appender.Server": '2,5,0,WorldServer.log,w',
-        "Logger.network": "5,Server" if generation["mode"] == BASIC_MOVEMENT_MODE else "4,Server",
+        "Logger.network": "5,Server" if generation["mode"] in {BASIC_MOVEMENT_MODE, RUN_SPEED_MODE} else "4,Server",
         "Logger.network.opcode": "4,Server",
     }
     auth_source = (REPO_ROOT / "src/server/apps/authserver/authserver.conf.dist").read_text()
@@ -1057,6 +1092,8 @@ def preflight_prepare(args: argparse.Namespace) -> dict[str, object]:
     dbc_root = args.server_dbc_root.resolve() if args.server_dbc_root else data_root / "dbc"
     if not dbc_root.is_dir() or not (data_root / "maps").is_dir():
         raise RuntimeError("data candidates must contain readable server DBC and Cataclysm maps directories")
+    if args.mode == RUN_SPEED_MODE:
+        verify_run_speed_aura_source(dbc_root)
     wine_runner = args.wine_runner.resolve()
     wine = next(
         (path for path in (wine_runner / "bin/wine64", wine_runner / "bin/wine")
@@ -1583,6 +1620,9 @@ def run_client(args: argparse.Namespace) -> None:
     require_unused(AUTH_PORT)
     require_unused(generation["ports"]["world"])
     paths = generation["paths"]
+    if generation["mode"] == RUN_SPEED_MODE:
+        # Re-seed on a transient retry too; a previous login may have consumed the saved aura.
+        mysql(manifest, generation, run_speed_aura_seed_sql(), generation["schemas"]["characters"])
     popens: dict[str, subprocess.Popen[bytes]] = {}
     outputs: list[object] = []
     try:
@@ -1831,14 +1871,34 @@ def movement_heartbeat_count(generation: Generation) -> int:
     return after_sync.count(MOVEMENT_HEARTBEAT_MARKER)
 
 
+def run_speed_acknowledgements(generation: Generation) -> list[dict[str, int | float]]:
+    after_map = world_log_text(generation).partition("Finished object update bootstrap after adding to map")[2]
+    after_sync = after_map.partition(IN_WORLD_CONTROL_MARKER)[2]
+    after_heartbeat = after_sync.partition(MOVEMENT_HEARTBEAT_MARKER)[2]
+    pending: dict[int, float] = {}
+    accepted = []
+    pattern = (
+        r"(Sent Cataclysm run-speed change|Accepted Cataclysm run-speed acknowledgement): "
+        r"counter=(\d+), speed=([-+0-9.eE]+)(?=\s|$)"
+    )
+    for kind, counter_text, speed_text in re.findall(pattern, after_heartbeat):
+        counter, speed = int(counter_text), float(speed_text)
+        if kind.startswith("Sent"):
+            pending[counter] = speed
+        elif pending.pop(counter, None) == speed == 7.0:
+            accepted.append({"counter": counter, "speed": speed})
+    return accepted
+
+
 POST_MARKER_MODES = frozenset({
-    INITIAL_POST_LOAD_PACKETS_MODE, MAP_INSERTION_MODE, IN_WORLD_CONTROL_MODE, BASIC_MOVEMENT_MODE,
+    INITIAL_POST_LOAD_PACKETS_MODE, MAP_INSERTION_MODE, IN_WORLD_CONTROL_MODE, BASIC_MOVEMENT_MODE, RUN_SPEED_MODE,
 })
 POST_MARKER_COUNTERS = {
     INITIAL_POST_LOAD_PACKETS_MODE: initial_packets_marker_count,
     MAP_INSERTION_MODE: map_insertion_marker_count,
     IN_WORLD_CONTROL_MODE: in_world_control_marker_count,
     BASIC_MOVEMENT_MODE: movement_heartbeat_count,
+    RUN_SPEED_MODE: lambda generation: len(run_speed_acknowledgements(generation)),
 }
 
 
@@ -1975,8 +2035,9 @@ def sanitized_evidence(
     selection_mode = generation["mode"] == CHARACTER_SELECTION_MODE
     initial_packets_mode = generation["mode"] == INITIAL_POST_LOAD_PACKETS_MODE
     map_insertion_mode = generation["mode"] == MAP_INSERTION_MODE
-    basic_movement_mode = generation["mode"] == BASIC_MOVEMENT_MODE
-    in_world_control_mode = generation["mode"] in {IN_WORLD_CONTROL_MODE, BASIC_MOVEMENT_MODE}
+    run_speed_mode = generation["mode"] == RUN_SPEED_MODE
+    basic_movement_mode = generation["mode"] in {BASIC_MOVEMENT_MODE, RUN_SPEED_MODE}
+    in_world_control_mode = generation["mode"] in {IN_WORLD_CONTROL_MODE, BASIC_MOVEMENT_MODE, RUN_SPEED_MODE}
     login_mode = selection_mode or initial_packets_mode or map_insertion_mode or in_world_control_mode
     owned_window = owned_window_evidence(generation) if character_mode else (
         Path(generation["paths"]["raw_evidence"]) / "window.xprop"
@@ -1988,7 +2049,8 @@ def sanitized_evidence(
         "build": CLIENT_BUILD,
         "mode": generation["mode"],
         "outcome": (
-            "basic_movement_pass_candidate" if basic_movement_mode and "characters_completed" in milestones
+            "run_speed_change_candidate" if run_speed_mode and "characters_completed" in milestones
+            else "basic_movement_pass_candidate" if basic_movement_mode and "characters_completed" in milestones
             else "in_world_control_bootstrap_candidate" if in_world_control_mode and "characters_completed" in milestones
             else "map_insertion_object_bootstrap_candidate" if map_insertion_mode and "characters_completed" in milestones
             else "initial_post_load_packets_candidate" if initial_packets_mode and "characters_completed" in milestones
@@ -2015,6 +2077,7 @@ def sanitized_evidence(
         "in_world_control_packet_prefix": in_world_control_prefix_value if in_world_control_mode else None,
         "in_world_control_marker_count": in_world_control_marker_count_value if in_world_control_mode else None,
         "movement_heartbeat_count": movement_heartbeat_count_value if basic_movement_mode else None,
+        "run_speed_acknowledgements": run_speed_acknowledgements(generation) if run_speed_mode else None,
         "post_marker_hold_seconds": (
             generation.get("post_marker_hold_seconds", 0) if generation["mode"] in POST_MARKER_MODES else None
         ),
@@ -2056,8 +2119,9 @@ def verify(args: argparse.Namespace) -> None:
     selection_mode = generation["mode"] == CHARACTER_SELECTION_MODE
     initial_packets_mode = generation["mode"] == INITIAL_POST_LOAD_PACKETS_MODE
     map_insertion_mode = generation["mode"] == MAP_INSERTION_MODE
-    basic_movement_mode = generation["mode"] == BASIC_MOVEMENT_MODE
-    in_world_control_mode = generation["mode"] in {IN_WORLD_CONTROL_MODE, BASIC_MOVEMENT_MODE}
+    run_speed_mode = generation["mode"] == RUN_SPEED_MODE
+    basic_movement_mode = generation["mode"] in {BASIC_MOVEMENT_MODE, RUN_SPEED_MODE}
+    in_world_control_mode = generation["mode"] in {IN_WORLD_CONTROL_MODE, BASIC_MOVEMENT_MODE, RUN_SPEED_MODE}
     login_mode = selection_mode or initial_packets_mode or map_insertion_mode or in_world_control_mode
     rows = character_row_count(manifest, generation) if character_mode else None
     realm_count = realm_character_count(manifest, generation) if populated_mode else None
@@ -2148,9 +2212,12 @@ def verify(args: argparse.Namespace) -> None:
             )
         if basic_movement_mode:
             character_ok = character_ok and evidence["movement_heartbeat_count"] > 0
+        if run_speed_mode:
+            character_ok = character_ok and bool(evidence["run_speed_acknowledgements"])
         if character_ok:
             evidence["outcome"] = (
-                "basic_movement_pass" if basic_movement_mode
+                "run_speed_change_pass" if run_speed_mode
+                else "basic_movement_pass" if basic_movement_mode
                 else "in_world_control_bootstrap_pass" if in_world_control_mode
                 else "map_insertion_object_bootstrap_pass" if map_insertion_mode
                 else "initial_post_load_packets_pass" if initial_packets_mode
@@ -2354,6 +2421,7 @@ def comparison_projection(evidence: dict[str, object]) -> dict[str, object]:
         ),
         "in_world_control_marker_count": evidence.get("in_world_control_marker_count"),
         "movement_heartbeat_observed": (evidence.get("movement_heartbeat_count") or 0) > 0,
+        "run_speed_acknowledgement_observed": bool(evidence.get("run_speed_acknowledgements")),
         "post_marker_hold_seconds": evidence.get("post_marker_hold_seconds"),
         "post_marker_snapshots": evidence.get("post_marker_snapshots"),
         "stability_seconds": evidence.get("stability_seconds"),
@@ -2660,6 +2728,34 @@ four Completed: COP_GET_CHARACTERS result=TRUE
         projection = comparison_projection(movement_evidence)
         assert projection == comparison_projection({**movement_evidence, "movement_heartbeat_count": 2})
         assert projection != comparison_projection({**movement_evidence, "movement_heartbeat_count": 0})
+        assert plan_number(RUN_SPEED_MODE) == "16"
+        prefix = ("Finished object update bootstrap after adding to map\n" + IN_WORLD_CONTROL_MARKER +
+                  "\n" + MOVEMENT_HEARTBEAT_MARKER + "\n")
+        sent = "Sent Cataclysm run-speed change: counter=7, speed=7\n"
+        accepted = "Accepted Cataclysm run-speed acknowledgement: counter=7, speed=7\n"
+        for log, expected in (
+            (prefix + accepted, []),
+            (sent + accepted, []),
+            (prefix + sent + accepted.replace("counter=7", "counter=8"), []),
+            (prefix + sent + accepted.replace("speed=7", "speed=8"), []),
+            (prefix + sent + accepted, [{"counter": 7, "speed": 7.0}]),
+            (prefix + sent + accepted + accepted, [{"counter": 7, "speed": 7.0}]),
+        ):
+            (raw / "WorldServer.log").write_text(log)
+            assert run_speed_acknowledgements(enum_generation) == expected
+        row = [0] * 234
+        row[0], row[71], row[95], row[80] = RUN_SPEED_AURA, 6, 31, RUN_SPEED_AURA_AMOUNT - 1
+        dbc_header = struct.pack("<4s4I", b"WDBC", 1, 234, 936, 1)
+        (raw / "Spell.dbc").write_bytes(dbc_header + struct.pack("<234I", *row) + b"\0")
+        verify_run_speed_aura_source(raw)
+        row[95] = 0
+        (raw / "Spell.dbc").write_bytes(dbc_header + struct.pack("<234I", *row) + b"\0")
+        try:
+            verify_run_speed_aura_source(raw)
+        except RuntimeError:
+            pass
+        else:
+            raise AssertionError("non-speed aura fixture was accepted")
     auth_keys = (
         "RealmServerPort", "BindIP", "LogsDir", "PidFile", "RealmsStateUpdateDelay",
         "LoginDatabaseInfo", "Updates.EnableDatabases", "Updates.AutoSetup", "StrictVersionCheck",
@@ -2726,7 +2822,7 @@ def parser() -> argparse.ArgumentParser:
     prepare_parser.add_argument(
         "--mode", choices=(
             "no-login", "authentication", "character-screen", POPULATED_MODE, CHARACTER_SELECTION_MODE,
-            INITIAL_POST_LOAD_PACKETS_MODE, MAP_INSERTION_MODE, IN_WORLD_CONTROL_MODE, BASIC_MOVEMENT_MODE,
+            INITIAL_POST_LOAD_PACKETS_MODE, MAP_INSERTION_MODE, IN_WORLD_CONTROL_MODE, BASIC_MOVEMENT_MODE, RUN_SPEED_MODE,
         ), default="authentication",
     )
     prepare_parser.add_argument("--minimum-free-gib", type=int, default=25)

--- a/plan/16-movement-acknowledgement-speed-contract.md
+++ b/plan/16-movement-acknowledgement-speed-contract.md
@@ -2,7 +2,5 @@
 
 Canonical issue: [#34](https://github.com/trolloks/azerothcore-cata/issues/34)
 
-Status: blocked by #33 (Plan 15). Continues the "Movement" plan family: proves a server-initiated
-speed change (or teleport ack, if Plan 15's evidence points that way instead) is correctly
-acknowledged by the client and accepted by the server. Ack counters, opcode numbers, and payload
-shape must be derived from the pinned Cataclysm reference before implementation.
+Status: in progress. The canonical issue defines the run-speed request, acknowledgement, and
+observer update contract, with local packet checks followed by one isolated client acceptance run.

--- a/plan/client-automation.md
+++ b/plan/client-automation.md
@@ -4,6 +4,15 @@ Reference for `run --auto-login` in `apps/cata/run_real_client_authentication.py
 describes focus acquisition and input delivery for the isolated client. Successful login and
 character selection do not prove that the world loading screen has dismissed.
 
+## Build and run budget
+
+Default to one server build and one isolated client acceptance run per completed change. Finish
+local packet checks before launching the client, then reuse the same binaries. Do not require two
+fresh generations automatically. Repeat only when a failure or relevant change requires new
+evidence, and state what the repeat will verify. Retry transient failures in the existing generation
+as described below. Earlier plans' two-generation requirements are historical, not the default for
+new work.
+
 ## Window discovery
 
 `owned_wow_window()` scans `wmctrl -lpGx` for a window whose PID is in the generation's own
@@ -190,7 +199,8 @@ future run does not have to reconstruct them:
 cd /mnt/e1384d9e-bede-40dd-8b1c-be0beb488490/Fun/azerothcore-cata
 M="/mnt/e1384d9e-bede-40dd-8b1c-be0beb488490/Fun/.plan11-runs/auth-15595/manifest.json"
 
-# The binaries must report the current HEAD, so rebuild before every prepare.
+# Build once when authorized; reuse these binaries for subsequent prepare/run operations.
+# The binaries must report the current HEAD. Rebuild if their recorded revision is stale.
 cmake --build var/build-plan7 --target revision.h worldserver authserver -j "$(nproc)"
 
 python3 apps/cata/run_real_client_authentication.py reset --manifest "$M"

--- a/plan/client-automation.md
+++ b/plan/client-automation.md
@@ -189,6 +189,13 @@ successful run. For a longer interactive observation, increase both limits.
 `--mode in-world-control-bootstrap` is the mode that seeds a character and drives it to world
 entry, as opposed to the auth-only modes.
 
+`--mode run-speed-change` also seeds a saved Sprint aura in the disposable character database.
+Its synthetic 60-second duration lets normal aura expiry restore run speed after world entry.
+Acceptance requires a sent speed change and a matching accepted acknowledgement after the first
+heartbeat, followed by a stable hold. Use `--stability-seconds 30 --timeout 180` for this mode.
+The fixture checks Sprint's effect against the current server DBC before preparation. It does
+not modify the source DBC or claim that 60 seconds is Sprint's retail duration.
+
 ## The exact harness invocation
 
 Recovering these arguments from scratch is slow and they are not stored anywhere the

--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -46,6 +46,7 @@
 #include "MoveSpline.h"
 #include "MoveSplineInit.h"
 #include "MovementGenerator.h"
+#include "MovementPackets.h"
 #include "ObjectAccessor.h"
 #include "ObjectMgr.h"
 #include "OutdoorPvP.h"
@@ -11355,16 +11356,31 @@ void Unit::SetSpeed(UnitMoveType mtype, float rate, bool forced)
 void Unit::SendSpeedToController(UnitMoveType mtype, Player* target) const
 {
     SpeedOpcodePair const& speedOpcodes = SetSpeed2Opc_table[mtype];
-    uint32 const counter = target->GetSession()->GetOrderCounter();
+    uint32 counter = target->GetSession()->GetOrderCounter();
+
+    if (mtype == MOVE_RUN)
+    {
+        // The map-change guard rejects the boundary counter itself, including zero at login.
+        if (counter == target->GetMapChangeOrderCounter())
+        {
+            target->GetSession()->IncrementOrderCounter();
+            counter = target->GetSession()->GetOrderCounter();
+        }
+        float const speed = GetSpeed(mtype);
+        m_pendingRunSpeedChange = PendingRunSpeedChange{ counter, speed };
+        WorldPacket data(SMSG_MOVE_SET_RUN_SPEED, 17);
+        WorldPackets::Movement::WriteRunSpeedChange(data, GetGUID(), counter, speed);
+        target->GetSession()->SendPacket(&data);
+        target->GetSession()->IncrementOrderCounter();
+        LOG_DEBUG("network", "Sent Cataclysm run-speed change: counter={}, speed={}", counter, speed);
+        return;
+    }
 
     ++target->m_forced_speed_changes[mtype];
 
     WorldPacket data(speedOpcodes[static_cast<size_t>(SpeedOpcodeIndex::PC)], 18);
     data << GetPackGUID();
     data << counter;
-    if (mtype == MOVE_RUN)
-        data << uint8(0);
-
     data << GetSpeed(mtype);
     target->GetSession()->SendPacket(&data);
     target->GetSession()->IncrementOrderCounter();

--- a/src/server/game/Entities/Unit/Unit.h
+++ b/src/server/game/Entities/Unit/Unit.h
@@ -33,6 +33,7 @@
 #include "UnitUtils.h"
 #include <boost/container/flat_map.hpp>
 #include <functional>
+#include <optional>
 #include <utility>
 
 #define WORLD_TRIGGER   12999
@@ -651,7 +652,7 @@ typedef const OpcodeServer SpeedOpcodePair[static_cast<size_t>(SpeedOpcodeIndex:
 SpeedOpcodePair SetSpeed2Opc_table[MAX_MOVE_TYPE] =
 {
     {SMSG_FORCE_WALK_SPEED_CHANGE,        SMSG_SPLINE_SET_WALK_SPEED,           MSG_MOVE_SET_WALK_SPEED_SERVER},
-    {SMSG_FORCE_RUN_SPEED_CHANGE,         SMSG_SPLINE_SET_RUN_SPEED,            MSG_MOVE_SET_RUN_SPEED_SERVER},
+    {SMSG_MOVE_SET_RUN_SPEED,             SMSG_SPLINE_SET_RUN_SPEED,            SMSG_MOVE_UPDATE_RUN_SPEED},
     {SMSG_FORCE_RUN_BACK_SPEED_CHANGE,    SMSG_SPLINE_SET_RUN_BACK_SPEED,       MSG_MOVE_SET_RUN_BACK_SPEED_SERVER},
     {SMSG_FORCE_SWIM_SPEED_CHANGE,        SMSG_SPLINE_SET_SWIM_SPEED,           MSG_MOVE_SET_SWIM_SPEED_SERVER},
     {SMSG_FORCE_SWIM_BACK_SPEED_CHANGE,   SMSG_SPLINE_SET_SWIM_BACK_SPEED,      MSG_MOVE_SET_SWIM_BACK_SPEED_SERVER},
@@ -1757,6 +1758,13 @@ public:
     void SetSpeed(UnitMoveType mtype, float rate, bool forced = false);
     void SetSpeedRate(UnitMoveType mtype, float rate) { m_speed_rate[mtype] = rate; }
     void SendSpeedToController(UnitMoveType mtype, Player* target) const;
+
+    struct PendingRunSpeedChange
+    {
+        uint32 Counter;
+        float Speed;
+    };
+    mutable std::optional<PendingRunSpeedChange> m_pendingRunSpeedChange;
 
     void propagateSpeedChange() { GetMotionMaster()->propagateSpeedChange(); }
 

--- a/src/server/game/Handlers/MovementHandler.cpp
+++ b/src/server/game/Handlers/MovementHandler.cpp
@@ -27,6 +27,7 @@
 #include "Log.h"
 #include "MapMgr.h"
 #include "MathUtil.h"
+#include "MovementPackets.h"
 #include "ObjectMgr.h"
 #include "Opcodes.h"
 #include "Pet.h"
@@ -680,6 +681,45 @@ bool WorldSession::ProcessMovementInfo(MovementInfo& movementInfo, Unit* mover, 
     return true;
 }
 
+void WorldSession::HandleForceRunSpeedChangeAck(WorldPacket& recvData)
+{
+    MovementInfo movementInfo;
+    uint32 counter;
+    float speed;
+    WorldPackets::Movement::ReadRunSpeedChangeAck(recvData, movementInfo, counter, speed);
+
+    Unit* mover = _player->m_mover;
+    if (!mover || movementInfo.guid != mover->GetGUID() || movementInfo.guid != _player->GetGUID())
+        return;
+    if (counter <= _player->GetMapChangeOrderCounter())
+        return;
+
+    auto const pending = mover->m_pendingRunSpeedChange;
+    if (!pending || pending->Counter != counter)
+        return;
+    if (std::fabs(pending->Speed - speed) > 0.01f)
+    {
+        LOG_ERROR("network", "Rejected Cataclysm run-speed acknowledgement: counter={}, expected={}, received={}",
+            counter, pending->Speed, speed);
+        KickPlayer("Incorrect run speed acknowledgement");
+        return;
+    }
+
+    SanitizeMovementFlags(&movementInfo);
+    if (!ProcessMovementInfo(movementInfo, mover, _player, recvData))
+        return;
+
+    // Movement hooks may have sent a newer speed change while processing this acknowledgement.
+    if (!mover->m_pendingRunSpeedChange || mover->m_pendingRunSpeedChange->Counter != counter)
+        return;
+    mover->m_pendingRunSpeedChange.reset();
+    sScriptMgr->AnticheatSetUnderACKmount(_player);
+    WorldPacket data(SMSG_MOVE_UPDATE_RUN_SPEED);
+    WorldPackets::Movement::WriteRunSpeedUpdate(data, movementInfo, pending->Speed);
+    mover->SendMessageToSet(&data, _player);
+    LOG_DEBUG("network", "Accepted Cataclysm run-speed acknowledgement: counter={}, speed={}", counter, pending->Speed);
+}
+
 void WorldSession::HandleForceSpeedChangeAck(WorldPacket& recvData)
 {
     uint32 opcode = recvData.GetOpcode();
@@ -725,8 +765,7 @@ void WorldSession::HandleForceSpeedChangeAck(WorldPacket& recvData)
         return;
     }
 
-    // client ACK send one packet for mounted/run case and need skip all except last from its
-    // in other cases anti-cheat check can be fail in false case
+    // Other speed types still use the legacy acknowledgement path.
     UnitMoveType move_type;
     UnitMoveType force_move_type;
 
@@ -735,7 +774,6 @@ void WorldSession::HandleForceSpeedChangeAck(WorldPacket& recvData)
     switch (opcode)
     {
         case CMSG_FORCE_WALK_SPEED_CHANGE_ACK:          move_type = MOVE_WALK;          force_move_type = MOVE_WALK;        break;
-        case CMSG_FORCE_RUN_SPEED_CHANGE_ACK:           move_type = MOVE_RUN;           force_move_type = MOVE_RUN;         break;
         case CMSG_FORCE_RUN_BACK_SPEED_CHANGE_ACK:      move_type = MOVE_RUN_BACK;      force_move_type = MOVE_RUN_BACK;    break;
         case CMSG_FORCE_SWIM_SPEED_CHANGE_ACK:          move_type = MOVE_SWIM;          force_move_type = MOVE_SWIM;        break;
         case CMSG_FORCE_SWIM_BACK_SPEED_CHANGE_ACK:     move_type = MOVE_SWIM_BACK;     force_move_type = MOVE_SWIM_BACK;   break;
@@ -756,8 +794,7 @@ void WorldSession::HandleForceSpeedChangeAck(WorldPacket& recvData)
     data << newspeed;
     mover->SendMessageToSet(&data, _player);
 
-    // skip all forced speed changes except last and unexpected
-    // in run/mounted case used one ACK and it must be skipped.m_forced_speed_changes[MOVE_RUN} store both.
+    // Skip all forced speed changes except the last and unexpected acknowledgements.
     if (_player->m_forced_speed_changes[force_move_type] > 0)
     {
         --_player->m_forced_speed_changes[force_move_type];

--- a/src/server/game/Server/Packets/MovementPackets.cpp
+++ b/src/server/game/Server/Packets/MovementPackets.cpp
@@ -199,6 +199,197 @@ void WorldPackets::Movement::WriteMovementUpdate(WorldPacket& packet, MovementIn
     packet.WriteByteSeq(guid[1]);
 }
 
+void WorldPackets::Movement::WriteRunSpeedChange(WorldPacket& packet, ObjectGuid const& guid, uint32 counter, float speed)
+{
+    for (uint8 index : { 6, 1, 5, 2, 7, 0, 3, 4 })
+        packet.WriteBit(guid[index]);
+    packet.FlushBits();
+    for (uint8 index : { 5, 3, 1, 4 })
+        packet.WriteByteSeq(guid[index]);
+    packet << counter << speed;
+    for (uint8 index : { 6, 0, 7, 2 })
+        packet.WriteByteSeq(guid[index]);
+}
+
+void WorldPackets::Movement::ReadRunSpeedChangeAck(
+    WorldPacket& packet, MovementInfo& info, uint32& counter, float& speed)
+{
+    info = MovementInfo();
+    packet >> counter >> info.pos.m_positionX >> speed >> info.pos.m_positionZ >> info.pos.m_positionY;
+    for (uint8 index : { 2, 4, 1, 7 })
+        info.guid[index] = packet.ReadBit();
+    bool hasOrientation = !packet.ReadBit();
+    bool hasFallData = packet.ReadBit();
+    info.guid[0] = packet.ReadBit();
+    bool hasSpline = packet.ReadBit();
+    bool hasTransport = packet.ReadBit();
+    bool hasTimestamp = !packet.ReadBit();
+    bool hasFlags2 = !packet.ReadBit();
+    info.guid[6] = packet.ReadBit();
+    packet.ReadBit();
+    bool hasSplineElevation = !packet.ReadBit();
+    bool hasPitch = !packet.ReadBit();
+    info.guid[5] = packet.ReadBit();
+    bool hasFlags = !packet.ReadBit();
+    info.guid[3] = packet.ReadBit();
+    bool hasVehicleId = false;
+    bool hasTransportTime2 = false;
+    if (hasTransport)
+    {
+        hasVehicleId = packet.ReadBit();
+        info.transport.guid[5] = packet.ReadBit();
+        hasTransportTime2 = packet.ReadBit();
+        for (uint8 index : { 3, 2, 0, 7, 6, 1, 4 })
+            info.transport.guid[index] = packet.ReadBit();
+    }
+    if (hasFlags)
+    {
+        uint32 flags = packet.ReadBits(30);
+        info.flags = (flags & 0x000001FF) | ((flags & 0x03FFFE00) << 1) | ((flags & 0x3C000000) << 2);
+    }
+    bool hasFallDirection = hasFallData && packet.ReadBit();
+    if (hasFlags2)
+    {
+        uint16 flags = packet.ReadBits(12);
+        info.flags2 = (flags & 0x03C3) | ((flags & 0x001C) << 1) | ((flags & 0x0020) >> 3) |
+            ((flags & 0xE000) >> 3) | ((flags & 0x1C00) << 3);
+    }
+    if (hasTransport)
+        info.AddMovementFlag(MOVEMENTFLAG_ONTRANSPORT);
+    if (hasSpline)
+        info.AddMovementFlag(MOVEMENTFLAG_SPLINE_ENABLED);
+    if (hasTransportTime2)
+        info.AddExtraMovementFlag(MOVEMENTFLAG2_INTERPOLATED_MOVEMENT);
+    for (uint8 index : { 6, 4, 1, 3, 5, 2, 7, 0 })
+        packet.ReadByteSeq(info.guid[index]);
+    if (hasTransport)
+    {
+        packet >> info.transport.pos.m_positionZ;
+        packet.ReadByteSeq(info.transport.guid[6]);
+        packet.ReadByteSeq(info.transport.guid[1]);
+        packet >> info.transport.pos.m_positionY;
+        packet.ReadByteSeq(info.transport.guid[0]);
+        packet.ReadByteSeq(info.transport.guid[5]);
+        if (hasTransportTime2)
+            packet >> info.transport.time2;
+        packet >> info.transport.pos.m_positionX >> info.transport.time;
+        packet.ReadByteSeq(info.transport.guid[7]);
+        info.transport.pos.SetOrientation(packet.read<float>());
+        packet.ReadByteSeq(info.transport.guid[3]);
+        if (hasVehicleId)
+            packet >> info.transport.vehicleId;
+        packet.ReadByteSeq(info.transport.guid[2]);
+        packet >> info.transport.seat;
+        packet.ReadByteSeq(info.transport.guid[4]);
+    }
+    if (hasFallData)
+    {
+        packet >> info.jump.zspeed;
+        if (hasFallDirection)
+            packet >> info.jump.xyspeed >> info.jump.sinAngle >> info.jump.cosAngle;
+        packet >> info.fallTime;
+    }
+    if (hasSplineElevation)
+        packet >> info.splineElevation;
+    if (hasPitch)
+        info.pitch = G3D::wrap(packet.read<float>(), float(-M_PI), float(M_PI));
+    if (hasTimestamp)
+        packet >> info.time;
+    if (hasOrientation)
+        info.pos.SetOrientation(packet.read<float>());
+    if (packet.rpos() != packet.size())
+        throw ByteBufferInvalidValueException("run-speed acknowledgement", "trailing bytes");
+}
+
+void WorldPackets::Movement::WriteRunSpeedUpdate(WorldPacket& packet, MovementInfo const& info, float speed)
+{
+    uint32 flags = MovementFlagsToClient(info.flags);
+    uint16 flags2 = ExtraMovementFlagsToClient(info.flags2) & 0x0FFF;
+    bool hasFallDirection = info.HasMovementFlag(MOVEMENTFLAG_FALLING);
+    bool hasFallData = hasFallDirection || info.fallTime != 0;
+    bool hasOrientation = !G3D::fuzzyEq(info.pos.GetOrientation(), 0.0f);
+    bool hasTransport = !info.transport.guid.IsEmpty();
+    bool hasVehicleId = hasTransport && info.transport.vehicleId != 0;
+    bool hasTransportTime2 = hasTransport && info.transport.time2 != 0;
+    bool hasPitch = info.HasMovementFlag(MOVEMENTFLAG_SWIMMING | MOVEMENTFLAG_FLYING) ||
+        info.HasExtraMovementFlag(MOVEMENTFLAG2_ALWAYS_ALLOW_PITCHING);
+    bool hasSplineElevation = info.HasMovementFlag(MOVEMENTFLAG_SPLINE_ELEVATION);
+    ObjectGuid const& guid = info.guid;
+    ObjectGuid const& transport = info.transport.guid;
+
+    packet << info.pos.GetPositionZ() << info.pos.GetPositionX() << info.pos.GetPositionY() << speed;
+    packet.WriteBit(guid[6]);
+    packet.WriteBit(!flags2);
+    packet.WriteBit(!hasPitch);
+    packet.WriteBit(guid[2]);
+    packet.WriteBit(guid[5]);
+    packet.WriteBit(!hasSplineElevation);
+    packet.WriteBit(info.HasMovementFlag(MOVEMENTFLAG_SPLINE_ENABLED));
+    packet.WriteBit(!flags);
+    packet.WriteBit(false); // Timestamp is always present in server movement updates.
+    packet.WriteBit(guid[1]);
+    if (flags2)
+        packet.WriteBits(flags2, 12);
+    packet.WriteBit(guid[3]);
+    if (flags)
+        packet.WriteBits(flags, 30);
+    packet.WriteBit(guid[7]);
+    packet.WriteBit(guid[0]);
+    packet.WriteBit(!hasOrientation);
+    packet.WriteBit(hasTransport);
+    if (hasTransport)
+    {
+        packet.WriteBit(transport[5]);
+        packet.WriteBit(hasTransportTime2);
+        packet.WriteBit(hasVehicleId);
+        for (uint8 index : { 7, 4, 2, 3, 6, 1, 0 })
+            packet.WriteBit(transport[index]);
+    }
+    packet.WriteBit(hasFallData);
+    if (hasFallData)
+        packet.WriteBit(hasFallDirection);
+    packet.WriteBit(guid[4]);
+    packet.WriteBit(false); // Height change failed.
+    packet.FlushBits();
+    if (hasTransport)
+    {
+        packet.WriteByteSeq(transport[4]);
+        packet.WriteByteSeq(transport[5]);
+        packet << info.transport.pos.GetPositionX() << info.transport.pos.GetOrientation();
+        for (uint8 index : { 1, 0, 6 })
+            packet.WriteByteSeq(transport[index]);
+        packet << info.transport.time;
+        packet.WriteByteSeq(transport[7]);
+        packet << info.transport.seat;
+        if (hasTransportTime2)
+            packet << info.transport.time2;
+        packet << info.transport.pos.GetPositionY();
+        packet.WriteByteSeq(transport[3]);
+        packet.WriteByteSeq(transport[2]);
+        if (hasVehicleId)
+            packet << info.transport.vehicleId;
+        packet << info.transport.pos.GetPositionZ();
+    }
+    packet << info.time;
+    if (hasFallData)
+    {
+        if (hasFallDirection)
+            packet << info.jump.cosAngle << info.jump.xyspeed << info.jump.sinAngle;
+        packet << info.jump.zspeed << info.fallTime;
+    }
+    if (hasPitch)
+        packet << info.pitch;
+    packet.WriteByteSeq(guid[6]);
+    if (hasSplineElevation)
+        packet << info.splineElevation;
+    for (uint8 index : { 5, 7, 4 })
+        packet.WriteByteSeq(guid[index]);
+    if (hasOrientation)
+        packet << info.pos.GetOrientation();
+    for (uint8 index : { 0, 3, 2, 1 })
+        packet.WriteByteSeq(guid[index]);
+}
+
 WorldPacket const* WorldPackets::Movement::MoveSetActiveMover::Write()
 {
     _worldPacket.WriteBit(MoverGUID[5]);

--- a/src/server/game/Server/Packets/MovementPackets.h
+++ b/src/server/game/Server/Packets/MovementPackets.h
@@ -21,6 +21,9 @@ namespace WorldPackets
         uint16 ExtraMovementFlagsToClient(uint16 flags);
         void ReadHeartbeat(WorldPacket& packet, MovementInfo& info);
         void WriteMovementUpdate(WorldPacket& packet, MovementInfo const& info);
+        void WriteRunSpeedChange(WorldPacket& packet, ObjectGuid const& guid, uint32 counter, float speed);
+        void ReadRunSpeedChangeAck(WorldPacket& packet, MovementInfo& info, uint32& counter, float& speed);
+        void WriteRunSpeedUpdate(WorldPacket& packet, MovementInfo const& info, float speed);
 
         class MoveSetActiveMover final : public ServerPacket
         {

--- a/src/server/game/Server/Protocol/Opcodes.cpp
+++ b/src/server/game/Server/Protocol/Opcodes.cpp
@@ -382,8 +382,6 @@ void OpcodeTable::Initialize()
     DEFINE_BIDIRECTIONAL_OPCODE(MSG_MOVE_STOP_SWIM, MSG_MOVE_STOP_SWIM, MSG_MOVE_STOP_SWIM_SERVER);
     /*0x0000*/ DEFINE_HANDLER(MSG_MOVE_SET_RUN_SPEED_CHEAT,                                          STATUS_NEVER,      PROCESS_INPLACE,        &WorldSession::Handle_NULL                              );
     DEFINE_BIDIRECTIONAL_OPCODE(MSG_MOVE_SET_RUN_SPEED_CHEAT, MSG_MOVE_SET_RUN_SPEED_CHEAT, MSG_MOVE_SET_RUN_SPEED_CHEAT_SERVER);
-    /*0x00CD*/ DEFINE_HANDLER(MSG_MOVE_SET_RUN_SPEED,                                                STATUS_NEVER,      PROCESS_INPLACE,        &WorldSession::Handle_NULL                              );
-    DEFINE_BIDIRECTIONAL_OPCODE(MSG_MOVE_SET_RUN_SPEED, MSG_MOVE_SET_RUN_SPEED, MSG_MOVE_SET_RUN_SPEED_SERVER);
     /*0x0000*/ DEFINE_HANDLER(MSG_MOVE_SET_RUN_BACK_SPEED_CHEAT,                                     STATUS_NEVER,      PROCESS_INPLACE,        &WorldSession::Handle_NULL                              );
     DEFINE_BIDIRECTIONAL_OPCODE(MSG_MOVE_SET_RUN_BACK_SPEED_CHEAT, MSG_MOVE_SET_RUN_BACK_SPEED_CHEAT, MSG_MOVE_SET_RUN_BACK_SPEED_CHEAT_SERVER);
     /*0x00CF*/ DEFINE_HANDLER(MSG_MOVE_SET_RUN_BACK_SPEED,                                           STATUS_NEVER,      PROCESS_INPLACE,        &WorldSession::Handle_NULL                              );
@@ -419,8 +417,9 @@ void OpcodeTable::Initialize()
     /*0x34B7*/ DEFINE_SERVER_OPCODE_HANDLER(SMSG_MOVE_LAND_WALK,                                     STATUS_NEVER);
     /*0x00E0*/ DEFINE_HANDLER(CMSG_MOVE_CHARM_PORT_CHEAT,                                            STATUS_NEVER,      PROCESS_INPLACE,        &WorldSession::Handle_NULL                              );
     /*0x00E1*/ DEFINE_HANDLER(CMSG_MOVE_SET_RAW_POSITION,                                            STATUS_NEVER,      PROCESS_INPLACE,        &WorldSession::Handle_NULL                              );
-    /*0x00E2*/ DEFINE_SERVER_OPCODE_HANDLER(SMSG_FORCE_RUN_SPEED_CHANGE,                             STATUS_NEVER);
-    /*0x00E3*/ DEFINE_HANDLER(CMSG_FORCE_RUN_SPEED_CHANGE_ACK,                                       STATUS_LOGGEDIN,   PROCESS_THREADSAFE,     &WorldSession::HandleForceSpeedChangeAck                );
+    DEFINE_SERVER_OPCODE_HANDLER(SMSG_MOVE_SET_RUN_SPEED,                                          STATUS_NEVER);
+    DEFINE_HANDLER(CMSG_MOVE_FORCE_RUN_SPEED_CHANGE_ACK, STATUS_LOGGEDIN, PROCESS_THREADSAFE,
+        &WorldSession::HandleForceRunSpeedChangeAck);
     /*0x00E4*/ DEFINE_SERVER_OPCODE_HANDLER(SMSG_FORCE_RUN_BACK_SPEED_CHANGE,                        STATUS_NEVER);
     /*0x00E5*/ DEFINE_HANDLER(CMSG_FORCE_RUN_BACK_SPEED_CHANGE_ACK,                                  STATUS_LOGGEDIN,   PROCESS_THREADSAFE,     &WorldSession::HandleForceSpeedChangeAck                );
     /*0x00E6*/ DEFINE_SERVER_OPCODE_HANDLER(SMSG_FORCE_SWIM_SPEED_CHANGE,                            STATUS_NEVER);
@@ -761,6 +760,7 @@ void OpcodeTable::Initialize()
     /*0x4316*/ DEFINE_SERVER_OPCODE_HANDLER(SMSG_GOSSIP_POI,                                         STATUS_NEVER);
     DEFINE_SERVER_OPCODE_HANDLER(SMSG_MOVE_SET_ACTIVE_MOVER,                                        STATUS_NEVER);
     DEFINE_SERVER_OPCODE_HANDLER(SMSG_MOVE_UPDATE,                                                  STATUS_NEVER);
+    DEFINE_SERVER_OPCODE_HANDLER(SMSG_MOVE_UPDATE_RUN_SPEED,                                        STATUS_NEVER);
     /*0x0D54*/ DEFINE_HANDLER(CMSG_CHAT_IGNORED,                                                     STATUS_LOGGEDIN,   PROCESS_THREADUNSAFE,   &WorldSession::HandleChatIgnoredOpcode                  );
     /*0x0228*/ DEFINE_HANDLER(CMSG_GM_SILENCE,                                                       STATUS_NEVER,      PROCESS_INPLACE,        &WorldSession::Handle_NULL                              );
     /*0x0229*/ DEFINE_HANDLER(CMSG_GM_REVEALTO,                                                      STATUS_NEVER,      PROCESS_INPLACE,        &WorldSession::Handle_NULL                              );

--- a/src/server/game/Server/Protocol/Opcodes.h
+++ b/src/server/game/Server/Protocol/Opcodes.h
@@ -163,7 +163,6 @@ enum OpcodeClient : uint16
     MSG_MOVE_START_SWIM                             = 0x3206,
     MSG_MOVE_STOP_SWIM                              = 0x3802,
     MSG_MOVE_SET_RUN_SPEED_CHEAT                    = 0x0000,
-    MSG_MOVE_SET_RUN_SPEED                          = 0x0CD,
     MSG_MOVE_SET_RUN_BACK_SPEED_CHEAT               = 0x0000,
     MSG_MOVE_SET_RUN_BACK_SPEED                     = 0x0CF,
     MSG_MOVE_SET_WALK_SPEED_CHEAT                   = 0x0000,
@@ -181,7 +180,7 @@ enum OpcodeClient : uint16
     MSG_MOVE_WORLDPORT_ACK                          = 0x2411,
     CMSG_MOVE_CHARM_PORT_CHEAT                      = 0x0E0,
     CMSG_MOVE_SET_RAW_POSITION                      = 0x0E1,
-    CMSG_FORCE_RUN_SPEED_CHANGE_ACK                 = 0x0E3,
+    CMSG_MOVE_FORCE_RUN_SPEED_CHANGE_ACK            = 0x7818,
     CMSG_FORCE_RUN_BACK_SPEED_CHANGE_ACK            = 0x0E5,
     CMSG_FORCE_SWIM_SPEED_CHANGE_ACK                = 0x0E7,
     CMSG_FORCE_MOVE_ROOT_ACK                        = 0x701E,
@@ -832,7 +831,7 @@ enum OpcodeServer : uint16
     SMSG_MONSTER_MOVE                               = 0x6E17,
     SMSG_MOVE_WATER_WALK                            = 0x75B1,
     SMSG_MOVE_LAND_WALK                             = 0x34B7,
-    SMSG_FORCE_RUN_SPEED_CHANGE                     = 0x0E2,
+    SMSG_MOVE_SET_RUN_SPEED                         = 0x3DB5,
     SMSG_FORCE_RUN_BACK_SPEED_CHANGE                = 0x0E4,
     SMSG_FORCE_SWIM_SPEED_CHANGE                    = 0x0E6,
     SMSG_FORCE_MOVE_ROOT                            = 0x0E8,
@@ -1000,6 +999,7 @@ enum OpcodeServer : uint16
     SMSG_GOSSIP_POI                                 = 0x4316,
     SMSG_MOVE_SET_ACTIVE_MOVER                       = 0x11B3,
     SMSG_MOVE_UPDATE                                 = 0x79A2,
+    SMSG_MOVE_UPDATE_RUN_SPEED                       = 0x14A6,
     SMSG_GM_PLAYER_INFO                             = 0x4A15,
     SMSG_LOGIN_VERIFY_WORLD                         = 0x2005,
     SMSG_LOAD_CUF_PROFILES                          = 0x50B1,
@@ -1407,8 +1407,6 @@ inline constexpr OpcodeServer MSG_MOVE_STOP_SWIM_SERVER =
     static_cast<OpcodeServer>(MSG_MOVE_STOP_SWIM);
 inline constexpr OpcodeServer MSG_MOVE_SET_RUN_SPEED_CHEAT_SERVER =
     static_cast<OpcodeServer>(MSG_MOVE_SET_RUN_SPEED_CHEAT);
-inline constexpr OpcodeServer MSG_MOVE_SET_RUN_SPEED_SERVER =
-    static_cast<OpcodeServer>(MSG_MOVE_SET_RUN_SPEED);
 inline constexpr OpcodeServer MSG_MOVE_SET_RUN_BACK_SPEED_CHEAT_SERVER =
     static_cast<OpcodeServer>(MSG_MOVE_SET_RUN_BACK_SPEED_CHEAT);
 inline constexpr OpcodeServer MSG_MOVE_SET_RUN_BACK_SPEED_SERVER =

--- a/src/server/game/Server/WorldSession.cpp
+++ b/src/server/game/Server/WorldSession.cpp
@@ -1115,6 +1115,11 @@ void WorldSession::ReadMovementInfo(WorldPacket& data, MovementInfo* mi)
             data >> mi->splineElevation;
     }
 
+    SanitizeMovementFlags(mi);
+}
+
+void WorldSession::SanitizeMovementFlags(MovementInfo* mi)
+{
     //! Anti-cheat checks. Please keep them in seperate if () blocks to maintain a clear overview.
     //! Might be subject to latency, so just remove improper flags.
 #ifdef ACORE_DEBUG

--- a/src/server/game/Server/WorldSession.h
+++ b/src/server/game/Server/WorldSession.h
@@ -436,6 +436,7 @@ public:
     void SendAddonsInfo();
 
     void ReadMovementInfo(WorldPacket& data, MovementInfo* mi);
+    void SanitizeMovementFlags(MovementInfo* mi);
     void WriteMovementInfo(WorldPacket* data, MovementInfo* mi);
     void SynchronizeMovement(MovementInfo& movementInfo);
     void HandleMoverRelocation(MovementInfo& movementInfo, Unit* mover);
@@ -719,6 +720,7 @@ public:                                                 // opcodes handlers
 
     void HandleMoveTeleportAck(WorldPacket& recvPacket);
     void HandleForceSpeedChangeAck(WorldPacket& recvData);
+    void HandleForceRunSpeedChangeAck(WorldPacket& recvData);
 
     void HandleRepopRequestOpcode(WorldPacket& recvPacket);
     void HandleAutostoreLootItemOpcode(WorldPacket& recvPacket);

--- a/src/test/server/game/Server/Packets/MovementPacketsTest.cpp
+++ b/src/test/server/game/Server/Packets/MovementPacketsTest.cpp
@@ -6,9 +6,11 @@
  */
 
 #include "MovementPackets.h"
+#include "IntegrationTestFixture.h"
 #include "Object.h"
 #include "Util.h"
 #include <gtest/gtest.h>
+#include <limits>
 #include <span>
 
 namespace
@@ -21,11 +23,11 @@ namespace
         "0000C840317151112C0000002B0000006181210000C03F000088C04D0000000000B0400000403F000000BF000080BE"
         "0000803E44332211";
 
-    WorldPacket Heartbeat(std::string const& hex)
+    WorldPacket ClientPacket(OpcodeClient opcode, std::string const& hex)
     {
         std::vector<uint8> bytes(hex.size() / 2);
         Acore::Impl::HexStrToByteArray(hex, bytes.data(), bytes.size());
-        WorldPacket packet(MSG_MOVE_HEARTBEAT, bytes.size());
+        WorldPacket packet(opcode, bytes.size());
         if (!bytes.empty())
             packet.append(bytes.data(), bytes.size());
         return packet;
@@ -41,7 +43,7 @@ namespace
 
 TEST(MovementPacketsTest, ReadsIdleHeartbeatAndWritesMovementUpdate)
 {
-    WorldPacket packet = Heartbeat(Idle);
+    WorldPacket packet = ClientPacket(MSG_MOVE_HEARTBEAT, Idle);
     MovementInfo info;
     WorldPackets::Movement::ReadHeartbeat(packet, info);
     EXPECT_EQ(info.guid, ObjectGuid(uint64(0x01020304)));
@@ -54,7 +56,7 @@ TEST(MovementPacketsTest, ReadsIdleHeartbeatAndWritesMovementUpdate)
     EXPECT_EQ(packet.rpos(), packet.size());
     EXPECT_EQ(MovementUpdate(info), "53784000000040000000803F0000404004030201030502");
 
-    packet = Heartbeat(Sparse);
+    packet = ClientPacket(MSG_MOVE_HEARTBEAT, Sparse);
     WorldPackets::Movement::ReadHeartbeat(packet, info);
     EXPECT_EQ(info.guid, ObjectGuid(uint64(0x0010000000000001)));
     EXPECT_EQ(info.time, 0u);
@@ -64,7 +66,7 @@ TEST(MovementPacketsTest, ReadsIdleHeartbeatAndWritesMovementUpdate)
 
 TEST(MovementPacketsTest, ReadsOptionalFieldsAndPreservesTheirWireLayout)
 {
-    WorldPacket packet = Heartbeat(OptionalFields);
+    WorldPacket packet = ClientPacket(MSG_MOVE_HEARTBEAT, OptionalFields);
     MovementInfo info;
     WorldPackets::Movement::ReadHeartbeat(packet, info);
     EXPECT_EQ(info.guid, ObjectGuid(uint64(0x0807060504030201)));
@@ -103,11 +105,11 @@ TEST(MovementPacketsTest, RejectsTruncatedAndTrailingHeartbeatData)
     {
         for (std::size_t length = 0; length < fixture.size(); length += 2)
         {
-            WorldPacket packet = Heartbeat(fixture.substr(0, length));
+            WorldPacket packet = ClientPacket(MSG_MOVE_HEARTBEAT, fixture.substr(0, length));
             MovementInfo info;
             EXPECT_THROW(WorldPackets::Movement::ReadHeartbeat(packet, info), ByteBufferException) << length;
         }
-        WorldPacket packet = Heartbeat(fixture + "00");
+        WorldPacket packet = ClientPacket(MSG_MOVE_HEARTBEAT, fixture + "00");
         MovementInfo info;
         EXPECT_THROW(WorldPackets::Movement::ReadHeartbeat(packet, info), ByteBufferInvalidValueException);
     }
@@ -132,4 +134,126 @@ TEST(MovementPacketsTest, TranslatesInternalFlagsAtTheWireBoundary)
     EXPECT_EQ(ExtraMovementFlagsToClient(MOVEMENTFLAG2_FULL_SPEED_PITCHING), 0x8u);
     EXPECT_EQ(ExtraMovementFlagsToClient(MOVEMENTFLAG2_ALWAYS_ALLOW_PITCHING), 0x10u);
     EXPECT_EQ(ExtraMovementFlagsToClient(MOVEMENTFLAG2_INTERPOLATED_MOVEMENT), 0x2000u);
+}
+
+TEST(MovementPacketsTest, ReadsRunSpeedAcknowledgementAndWritesBothServerPackets)
+{
+    struct Fixture
+    {
+        char const* Ack;
+        uint64 Guid;
+        char const* Request;
+        char const* Update;
+    };
+    for (Fixture const& fixture : std::initializer_list<Fixture>{
+        {
+            "403020100000803F000028410000404000000040AA26C00200030504030201",
+            0x01020304,
+            "56000240302010000028410503",
+            "000040400000803F0000004000002841756C000403020105000302"
+        },
+        {
+            "40302010000080BF0000284100004040000000400A76801100",
+            0x0010000000000001,
+            "8440302010000028411100",
+            "00004040000080BF0000004000002841E50C00000000001100"
+        },
+        {
+            "403020100000A03F0000284100007040000020C0F6917FF08002002020060403050702090000000CC121710000F04081"
+            "312B0000000000C8402A0000001100000040512C00000061FF41000088C00000B040000000BF0000403F4D0000000000"
+            "803E000080BE443322110000C03F",
+            0x0807060504030201,
+            "FF07050304403020100000284106000902",
+            "000070400000A03F000020C00000284198404210004006FFFC41310000C840000000407181212A00000011FF2B000000"
+            "0000F04051612C00000000000CC1443322110000403F0000B040000000BF000088C04D000000000080BE060000803E07"
+            "09040000C03F00050203"
+        }
+    })
+    {
+        WorldPacket packet = ClientPacket(CMSG_MOVE_FORCE_RUN_SPEED_CHANGE_ACK, fixture.Ack);
+        MovementInfo info;
+        uint32 counter;
+        float speed;
+        WorldPackets::Movement::ReadRunSpeedChangeAck(packet, info, counter, speed);
+        EXPECT_EQ(counter, 0x10203040u);
+        EXPECT_FLOAT_EQ(speed, 10.5f);
+        EXPECT_EQ(info.guid, ObjectGuid(fixture.Guid));
+        EXPECT_EQ(packet.rpos(), packet.size());
+
+        WorldPacket request(SMSG_MOVE_SET_RUN_SPEED);
+        WorldPackets::Movement::WriteRunSpeedChange(request, info.guid, counter, speed);
+        EXPECT_EQ(ByteArrayToHexStr(std::span<uint8 const>(request.contents(), request.size())), fixture.Request);
+        WorldPacket update(SMSG_MOVE_UPDATE_RUN_SPEED);
+        WorldPackets::Movement::WriteRunSpeedUpdate(update, info, speed);
+        EXPECT_EQ(ByteArrayToHexStr(std::span<uint8 const>(update.contents(), update.size())), fixture.Update);
+
+        std::string hex = fixture.Ack;
+        for (std::size_t length = 0; length < hex.size(); length += 2)
+        {
+            packet = ClientPacket(CMSG_MOVE_FORCE_RUN_SPEED_CHANGE_ACK, hex.substr(0, length));
+            EXPECT_THROW(WorldPackets::Movement::ReadRunSpeedChangeAck(packet, info, counter, speed),
+                ByteBufferException) << length;
+        }
+        packet = ClientPacket(CMSG_MOVE_FORCE_RUN_SPEED_CHANGE_ACK, hex + "00");
+        EXPECT_THROW(WorldPackets::Movement::ReadRunSpeedChangeAck(packet, info, counter, speed),
+            ByteBufferInvalidValueException);
+        packet = ClientPacket(CMSG_MOVE_FORCE_RUN_SPEED_CHANGE_ACK, hex);
+        packet.put<float>(8, std::numeric_limits<float>::quiet_NaN());
+        EXPECT_THROW(WorldPackets::Movement::ReadRunSpeedChangeAck(packet, info, counter, speed),
+            ByteBufferInvalidValueException);
+    }
+}
+
+using RunSpeedAcknowledgementTest = IntegrationTestFixture;
+
+TEST_F(RunSpeedAcknowledgementTest, TracksLatestRequestAndRejectsInvalidAcknowledgements)
+{
+    TestPlayer* player = CreateTestPlayer(0x01020304);
+    WorldSession* session = player->GetSession();
+    player->SetSpeedRate(MOVE_RUN, 1.5f);
+    player->SendSpeedToController(MOVE_RUN, player);
+    ASSERT_TRUE(player->m_pendingRunSpeedChange);
+    EXPECT_GT(player->m_pendingRunSpeedChange->Counter, player->GetMapChangeOrderCounter());
+    EXPECT_FLOAT_EQ(player->m_pendingRunSpeedChange->Speed, 10.5f);
+    uint32 firstCounter = player->m_pendingRunSpeedChange->Counter;
+    player->SendSpeedToController(MOVE_RUN, player);
+    EXPECT_GT(player->m_pendingRunSpeedChange->Counter, firstCounter);
+
+    std::string const ack =
+        "403020100000803F000028410000404000000040AA26C00200030504030201";
+    // No pending request: an unsolicited or duplicate acknowledgement cannot be accepted.
+    player->m_pendingRunSpeedChange.reset();
+    WorldPacket packet = ClientPacket(CMSG_MOVE_FORCE_RUN_SPEED_CHANGE_ACK, ack);
+    session->HandleForceRunSpeedChangeAck(packet);
+    EXPECT_FALSE(player->m_pendingRunSpeedChange);
+    EXPECT_FALSE(session->IsKicked());
+
+    // An older counter must be ignored before comparing the requested speed.
+    player->m_pendingRunSpeedChange = Unit::PendingRunSpeedChange{ 0x10203041, 7.0f };
+    packet = ClientPacket(CMSG_MOVE_FORCE_RUN_SPEED_CHANGE_ACK, ack);
+    session->HandleForceRunSpeedChangeAck(packet);
+    EXPECT_EQ(player->m_pendingRunSpeedChange->Counter, 0x10203041u);
+    EXPECT_FALSE(session->IsKicked());
+
+    // The map-change boundary is also stale, even if it matches the pending counter.
+    player->m_pendingRunSpeedChange = Unit::PendingRunSpeedChange{ 0, 7.0f };
+    packet = ClientPacket(CMSG_MOVE_FORCE_RUN_SPEED_CHANGE_ACK, ack);
+    packet.put<uint32>(0, 0);
+    session->HandleForceRunSpeedChangeAck(packet);
+    EXPECT_TRUE(player->m_pendingRunSpeedChange);
+    EXPECT_FALSE(session->IsKicked());
+
+    player->m_pendingRunSpeedChange = Unit::PendingRunSpeedChange{ 0x10203040, 7.0f };
+    packet = ClientPacket(CMSG_MOVE_FORCE_RUN_SPEED_CHANGE_ACK,
+        "40302010000080BF0000284100004040000000400A76801100");
+    session->HandleForceRunSpeedChangeAck(packet);
+    EXPECT_TRUE(player->m_pendingRunSpeedChange);
+    EXPECT_FALSE(session->IsKicked());
+
+    // A matching counter with the wrong speed is rejected without consuming the pending request.
+    packet = ClientPacket(CMSG_MOVE_FORCE_RUN_SPEED_CHANGE_ACK, ack);
+    session->HandleForceRunSpeedChangeAck(packet);
+    EXPECT_TRUE(player->m_pendingRunSpeedChange);
+    EXPECT_TRUE(session->IsKicked());
+    EXPECT_FLOAT_EQ(player->GetPositionX(), 0.0f);
 }


### PR DESCRIPTION
## Changes Proposed:

Run-speed changes still used WotLK opcode names and payloads, so the Cata client could not complete their acknowledgement handshake. Convert the request, acknowledgement, and observer update to the pinned Cata layouts. Check the latest pending counter and speed before processing movement or broadcasting the update.

Retain AC's mover restriction, map-change guard, movement validation, and hooks. The isolated runner now uses normal expiry of a saved Sprint aura to trigger a speed restoration while the player is idle. Project guidance also records the requested one-build, one-client-run default.

- [x] Core (units, players, creatures, game systems).
- [ ] Scripts (bosses, spell scripts, creature scripts).
- [ ] Database (SAI, creatures, etc).

### AI-assisted Pull Requests

- [x] AI tools were used entirely or partially to prepare this pull request.
  - Codex, GPT-6: implementation, synthetic fixtures, validation, review, and PR description.
- [x] I have read and understood the [AC guidelines for AI Agentic Engineering](https://www.azerothcore.org/wiki/agentic-engineering).

## Issues Addressed:

Closes #34.

## SOURCE:

- [ ] Live research on official servers.
- [ ] Sniffs.
- [ ] Video evidence, knowledge databases or other public sources.
- [x] Cherry-picked/adapted from another project, with upstream authors credited in the commit.

[TrinityCore's pinned movement sequences](https://github.com/TrinityCore/TrinityCore/blob/c699217775d90794158422387b07a917e161b582/src/server/game/Movement/MovementStructures.cpp) and its pending-counter validation. Shauren is the implementation commit author; Spp and Ovahlord are credited as co-authors.

## Tests Performed:

- One incremental build of `revision.h`, `worldserver`, `authserver`, and `unit_tests` passed on `abaa6d20199322d2400fc34f84efce416680b5a2`.
- Full unit suite: **5,947 passed, 5,487 skipped, one disabled; zero failures/errors**. Includes independent byte fixtures for all three packet layouts, malformed input checks, and pending-counter/mover/speed rejection checks.
- Runner self-check, focus regression checks, fixture generation, and current server DBC validation passed.
- **One real 4.3.4 client run**, generation 84: accepted run-speed restoration **counter 3, speed 7.0** after world entry and heartbeat; two ownership snapshots over a **30-second** stable hold; Northshire screen visually confirmed.
- Verification outcome `run_speed_change_pass`; protected inputs unchanged; reset `PASS`; owned containers and volumes removed.
- SQL style and `git diff --check` passed. C++ style reports only three pre-existing blank-line findings in `UpdateFields.h` (40, 186, 522).

Local evidence: generation 84 under `.plan11-runs/auth-15595/`, test XML `/tmp/cata-plan16-tests.xml`, build log `/tmp/cata-plan16-build.log`. No second client generation or build was needed.

## How to Test the Changes:

- [x] This pull request can be tested by following the reproduction steps in the linked issue.
- [x] Optional movement states need further in-game coverage.

1. Run `unit_tests --gtest_filter=MovementPacketsTest.*:RunSpeedAcknowledgementTest.*`.
2. Run `python3 apps/cata/run_real_client_authentication.py self-check`.
3. Use the isolated invocation in `plan/client-automation.md` with `--mode run-speed-change`, then run with `--auto-login --stability-seconds 30 --timeout 180`.
4. Let the character idle. Aura expiry must send a run-speed restoration to 7 and receive an accepted acknowledgement with the same counter. Confirm the in-world screen, verify the stable hold and isolation, then reset the owned resources.

## Known Issues and TODO List:

- This covers player run-speed acknowledgement while idle. Other speed types, vehicle/charm acknowledgement support, teleport, directional movement, and splines remain separate work.
- Optional movement fields and the observer update have synthetic fixture coverage. No second observer client is required for this slice.
- The saved Sprint fixture uses a synthetic 60-second duration so expiry happens after world entry. This does not claim retail Sprint duration or complete spell-data conversion.

## Self-review

No new findings at `abaa6d20199322d2400fc34f84efce416680b5a2`. The three existing `UpdateFields.h` style findings above are unchanged.

## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
