### PR TITLE
chore(Core): Reduce build and setup overhead

### DIFF
--- a/.agents/docs/build.md
+++ b/.agents/docs/build.md
@@ -16,4 +16,31 @@ make -j$(nproc) && make install
 
 C++20 required (`CMAKE_CXX_STANDARD 20`). Useful flags: `BUILD_TESTING=ON` (Google Test), `NOPCH=1` (disable precompiled headers). Full set in `conf/dist/config.cmake`. `compile_commands.json` is exported automatically.
 
+## Faster local builds
+
+Keep and reuse one build directory. Enable precompiled headers with `-DNOPCH=0`; the core PCH
+option is already on by default. Use a compiler cache through CMake's existing launcher settings:
+
+```bash
+cmake -S . -B build -DNOPCH=0 -DBUILD_TESTING=ON -DENABLE_TEST_COVERAGE=OFF \
+  -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
+cmake --build build --target worldserver authserver unit_tests -j 4
+```
+
+Choose parallelism for available cores and memory; this four-core host starts with four jobs.
+Changing PCH or compiler flags requires a rebuild, so settle these settings before the authorized
+build. Ccache's PCH support requires `sloppiness=pch_defines,time_macros`; see the
+[ccache manual](https://ccache.dev/manual/4.9.html#_precompiled_headers). Keep timestamped build
+metadata in generated files so content changes invalidate cached compilations.
+
+This workspace uses `var/build-plan7` and a repository-local `var/tools/ccache-run` launcher, with
+its cache under `var/cache/ccache`, capped at 2 GB. Its absolute launcher path is already stored in
+CMakeCache.txt. Reuse that configuration; the generic example above is for a new build directory.
+
+Coverage is opt-in: add `-DENABLE_TEST_COVERAGE=ON` before building when coverage is needed.
+Only that configuration exposes the `coverage` target. Ordinary tests use the normal compiler
+flags and avoid coverage instrumentation. Cache hits help unchanged compilations; real source or
+header changes still need compilation. Measure representative changes before claiming whole-build
+speedups.
+
 Tests (Google Test, in `src/test/`): configure `-DBUILD_TESTING=ON`, then `ctest` or `./src/test/unit_tests` from the build dir.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -146,16 +146,18 @@ endif()
 CU_RUN_HOOK("AFTER_SRC_LOAD")
 
 if (BUILD_TESTING AND BUILD_APPLICATION_WORLDSERVER)
-    # we use these flags to get code coverage
-    set(UNIT_TEST_CXX_FLAGS "-fprofile-arcs -ftest-coverage -fno-inline")
+    if (ENABLE_TEST_COVERAGE)
+        # we use these flags to get code coverage
+        set(UNIT_TEST_CXX_FLAGS "-fprofile-arcs -ftest-coverage -fno-inline")
 
-    # enable additional flags for GCC.
-    if ( CMAKE_CXX_COMPILER_ID MATCHES GNU )
-        set(UNIT_TEST_CXX_FLAGS "${UNIT_TEST_CXX_FLAGS} -fno-inline-small-functions -fno-default-inline")
+        # enable additional flags for GCC.
+        if ( CMAKE_CXX_COMPILER_ID MATCHES GNU )
+            set(UNIT_TEST_CXX_FLAGS "${UNIT_TEST_CXX_FLAGS} -fno-inline-small-functions -fno-default-inline")
+        endif()
+
+        message("Unit tests code coverage: enabling ${UNIT_TEST_CXX_FLAGS}")
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${UNIT_TEST_CXX_FLAGS}")
     endif()
-
-    message("Unit tests code coverage: enabling ${UNIT_TEST_CXX_FLAGS}")
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${UNIT_TEST_CXX_FLAGS}")
 
     include(src/cmake/googletest.cmake)
     fetch_googletest(
@@ -166,15 +168,18 @@ if (BUILD_TESTING AND BUILD_APPLICATION_WORLDSERVER)
     enable_testing()
     add_subdirectory(src/test)
 
-    add_custom_target(coverage DEPENDS coverage_command)
+    if (ENABLE_TEST_COVERAGE)
+        add_custom_target(coverage DEPENDS coverage_command)
 
-    add_custom_command(OUTPUT coverage_command
-        # Run unit tests.
-        COMMAND ctest
-        # Run the graphical front-end for code coverage.
-        COMMAND lcov    --directory src --capture --output-file coverage.info
-        COMMAND lcov    --remove coverage.info '/usr/*' '${CMAKE_BINARY_DIR}/googletest/*' '${CMAKE_CURRENT_SOURCE_DIR}/src/test/*' --output-file coverage.info
-        COMMAND genhtml -o ${CMAKE_CURRENT_SOURCE_DIR}/coverage-report coverage.info
-        WORKING_DIRECTORY "${CMAKE_BINARY_DIR}"
+        add_custom_command(OUTPUT coverage_command
+            # Run unit tests.
+            COMMAND ctest
+            # Run the graphical front-end for code coverage.
+            COMMAND lcov    --directory src --capture --output-file coverage.info
+            COMMAND lcov    --remove coverage.info '/usr/*' '${CMAKE_BINARY_DIR}/googletest/*'
+                '${CMAKE_CURRENT_SOURCE_DIR}/src/test/*' --output-file coverage.info
+            COMMAND genhtml -o ${CMAKE_CURRENT_SOURCE_DIR}/coverage-report coverage.info
+            WORKING_DIRECTORY "${CMAKE_BINARY_DIR}"
         )
+    endif()
 endif()

--- a/apps/cata/run_real_client_authentication.py
+++ b/apps/cata/run_real_client_authentication.py
@@ -1243,6 +1243,7 @@ def prepare(args: argparse.Namespace) -> None:
             "-e", f"MYSQL_ROOT_PASSWORD={manifest['mysql_root_password']}",
             "-p", f"127.0.0.1:{generation['ports']['mysql']}:3306",
             "-v", f"{generation['docker']['volume']}:/var/lib/mysql", str(inputs["mysql_image_id"]),
+            "--skip-log-bin",  # This disposable database has no replication or point-in-time recovery.
         ])
         generation["docker"]["container_id"] = result.stdout.decode().strip()
         save_manifest(manifest_path, manifest)

--- a/conf/dist/config.cmake
+++ b/conf/dist/config.cmake
@@ -95,6 +95,7 @@ foreach(TOOL_BUILD_NAME ${TOOLS_BUILD_LIST})
 endforeach()
 
 option(BUILD_TESTING       "Build unit tests"                                            0)
+option(ENABLE_TEST_COVERAGE "Instrument unit tests for code coverage"                    0)
 option(USE_SCRIPTPCH       "Use precompiled headers when compiling scripts"              1)
 option(USE_COREPCH         "Use precompiled headers when compiling servers"              1)
 option(WITH_WARNINGS       "Show all warnings during compile"                            0)

--- a/plan/client-automation.md
+++ b/plan/client-automation.md
@@ -13,6 +13,11 @@ evidence, and state what the repeat will verify. Retry transient failures in the
 as described below. Earlier plans' two-generation requirements are historical, not the default for
 new work.
 
+The disposable MySQL container starts with `--skip-log-bin`: acceptance runs do not need replication
+or point-in-time recovery logs. InnoDB commit flushing remains enabled. Restore the existing SQL
+cache into a fresh owned volume and verify the fixture as usual. Measure database restore separately
+from preflight and Wine startup when investigating `prepare` performance.
+
 ## Window discovery
 
 `owned_wow_window()` scans `wmctrl -lpGx` for a window whose PID is in the generation's own


### PR DESCRIPTION
## Changes Proposed:

Ordinary test builds always enabled coverage instrumentation, and each disposable acceptance database generated binary logs despite having no replication or recovery use. Make test coverage opt-in with `ENABLE_TEST_COVERAGE` and start the owned MySQL container with `--skip-log-bin`.

Build guidance now covers the existing compiler-cache and precompiled-header support. This workspace is configured to use both, with a local 2 GB ccache and four build jobs. The cache installation and CMakeCache settings are local; the PR documents their use.

- [x] Core (units, players, creatures, game systems).
- [ ] Scripts (bosses, spell scripts, creature scripts).
- [ ] Database (SAI, creatures, etc).

### AI-assisted Pull Requests

- [x] AI tools were used entirely or partially to prepare this pull request.
  - Codex, GPT-6: implementation, benchmarks, validation, review, and description.
- [x] I have read and understood the [AC guidelines for AI Agentic Engineering](https://www.azerothcore.org/wiki/agentic-engineering).

## Issues Addressed:

## SOURCE:

- [ ] Live research.
- [ ] Sniffs.
- [x] Public technical documentation.
- [ ] Adapted from another core or project.

[MySQL binary logging options](https://dev.mysql.com/doc/refman/8.4/en/replication-options-binary-log.html) and [ccache PCH requirements](https://ccache.dev/manual/4.9.html#_precompiled_headers).

## Tests Performed:

Sequential samples on this four-core i5-7400, GCC 13 Release host:

| Measurement | Before | After |
| --- | ---: | ---: |
| MovementHandler.cpp, uncached versus cache hit | 12.420s | 0.018s |
| MovementHandler.cpp, without versus with PCH | 12.420s | 5.876s |
| MovementPacketsTest.cpp, coverage on versus off | 28.434s | 20.536s |
| Same SQL dump restored into fresh MySQL volumes, binary logging on versus off | 195.993s | 158.895s |

The cache miss took 14.485s; uncached, cold-cache, and warm-cache object hashes matched. Creating the PCH took 17.420s once. These are individual compile samples, not whole-build speedup estimates.

The database comparison used the same 306 MB dump and pinned MySQL image. All **442 table checksums matched**. InnoDB commit flushing remained enabled in both runs. Both benchmark containers and volumes were removed.

Coverage ON/OFF configuration checks and the runner self-check passed. SQL style and whitespace checks passed; C++ style reports only the three pre-existing blank-line findings in `UpdateFields.h` at 40, 186, and 522.

One full validation build on `ed514bc9ef693d033f3a2e451ca6d97235a48b82` passed in **23m 53s**, using the new configuration and initially empty cache. This isn't a controlled comparison with the previous incremental build. The build emitted existing include-path warnings for the server executable paths from unchanged `src/server/apps/CMakeLists.txt`.

The full unit suite passed: **5,947 passed, 5,487 skipped, one disabled; zero failures/errors**.

One real 4.3.4 client run, generation 85, passed: run-speed acknowledgement counter 3/speed 7.0, two ownership snapshots over a 30-second stable hold, Northshire screen visually confirmed, and protected inputs unchanged. The owned database reported binary logging OFF and InnoDB commit flushing ON.

Full prepare profiling reproduced the faster SQL restore at **163.69s**. However, total prepare took **408.80s**, versus **293.39s** in generation 84: data copying rose from 1.24s to 99.51s, and preflight rose from 45.18s to 57.91s. **No overall prepare-time improvement is claimed from this run.** The controlled restore comparison above isolates the benefit of this change; copying and other setup stages still need investigation.

Reset passed; owned acceptance containers and volumes were removed. One full validation build and one client run were used. The focused compilation and SQL-restore benchmarks above were separate performance measurements.

## How to Test the Changes:

1. Configure with `BUILD_TESTING=ON` and `ENABLE_TEST_COVERAGE=OFF`; verify normal test compiler flags and run the unit suite. With coverage ON, verify the instrumentation flags and `coverage` target are present.
2. Follow `.agents/docs/build.md` to configure the compiler launcher and PCH. Inspect cache statistics after a necessary compilation. An ordinary no-op build is not a cache-hit benchmark.
3. Run the isolated client `prepare` invocation in `plan/client-automation.md`. Confirm the owned MySQL instance reports `@@log_bin=0` and that fixture checks pass. Profile prepare to separate restore time from hashing and Wine setup.
4. Run one client acceptance check with a 30-second stable hold, verify the in-world screen and protected inputs, then reset the owned resources.

## Known Issues and TODO List:

- Binary logging is disabled only in disposable acceptance containers. This changes no personal or production database configuration.
- The four-job setting follows this host's core count; no four-versus-six-job speedup is claimed.
- Coverage-report generation with lcov was not exercised. The opt-in configuration retains the existing coverage commands.

## Self-review

No new findings at `ed514bc9ef693d033f3a2e451ca6d97235a48b82`. The existing style findings above remain.

## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
