### PR TITLE
fix(Core): Convert remaining Cata update fields

### DIFF
--- a/apps/cata/seed_remaining_object_fields.py
+++ b/apps/cata/seed_remaining_object_fields.py
@@ -1,0 +1,134 @@
+"""Seed Plan 18 acceptance through the existing disposable-client harness."""
+import argparse
+import importlib.util
+import json
+from pathlib import Path
+import struct
+import sys
+
+repo = Path(__file__).resolve().parents[2]
+spec = importlib.util.spec_from_file_location('runner', repo / 'apps/cata/run_real_client_authentication.py')
+r = importlib.util.module_from_spec(spec)
+sys.modules[spec.name] = r
+spec.loader.exec_module(r)
+parser = argparse.ArgumentParser(description=__doc__)
+parser.add_argument('manifest', type=Path, help='prepared isolated client-run manifest')
+manifest_path = parser.parse_args().manifest.resolve()
+m = r.load_manifest(manifest_path)
+g = r.active_generation(m)
+if g['state'] not in {'prepared', 'inconclusive'} or g['mode'] != r.IN_WORLD_CONTROL_MODE:
+    raise RuntimeError('Requires a prepared in-world-control generation')
+r.assert_container_owned(m, g)
+characters = g['schemas']['characters']
+world = g['schemas']['world']
+
+# Verify the normal periodic-aura -> persistent-area-spell path in the actual server DBC.
+b = (Path(g['paths']['data']) / 'dbc/Spell.dbc').read_bytes()
+magic, count, fields, size, _ = struct.unpack_from('<4s4I', b)
+assert (magic, fields, size) == (b'WDBC', 234, 936)
+spells = {row[0]: row for row in struct.iter_unpack('<234I', b[20:20 + count * size])}
+aura, flame = spells[50247], spells[50249]
+assert (aura[71], aura[95], aura[98], aura[116]) == (6, 23, 330, 50249)
+assert (flame[71], flame[95], flame[131]) == (27, 4, 11030)
+item_templates = r.mysql(m, g,
+    'SELECT entry,ContainerSlots,MaxDurability FROM item_template WHERE entry IN (25,117,4496) ORDER BY entry;', world)
+assert item_templates.splitlines() == ['25\t0\t20', '117\t0\t0', '4496\t6\t0'], item_templates
+assert r.mysql(m, g, 'SELECT type,displayId FROM gameobject_template WHERE entry=2843;', world) == '3\t259'
+
+migration = (repo / 'data/sql/updates/pending_db_characters/rev_1788937529456601782.sql').read_text()
+old = ' '.join(str(i) for i in range(1, 37)) + ' '
+converted = (
+    ' '.join(str(i) for i in range(1, 22)) + ' ' + '0 ' * 9
+    + ' '.join(str(i) for i in range(22, 37)) + ' '
+)
+# Temporary shadow table exists only for this one mysql connection in our owned schema.
+query = 'CREATE TEMPORARY TABLE item_instance (guid INT PRIMARY KEY, enchantments TEXT NOT NULL);'
+cases = [old, converted, '', '1 2 3 ', old.rstrip()]
+query += 'INSERT INTO item_instance VALUES ' + ','.join(f"({i},'{value}')" for i, value in enumerate(cases)) + ';'
+query += migration + 'SELECT guid,HEX(enchantments) FROM item_instance ORDER BY guid;'
+query += migration + 'SELECT guid,HEX(enchantments) FROM item_instance ORDER BY guid;'
+rows = r.mysql(m, g, query, characters).splitlines()
+expected = [
+    f'{i}\t{value.encode().hex().upper()}'
+    for i, value in enumerate([converted, converted, '', '1 2 3 ', converted])
+]
+assert rows == expected * 2, 'Migration changed a modern/partial row or was not idempotent'
+
+owner = r.CHARACTER_GUID
+corpse_owner = owner + 1
+bag, food, sword = 900001, 900002, 900003
+x, y, z = r.CHARACTER_POSITION
+# A separate offline character owns the visible corpse, so logging in does not reclaim it.
+body_seed = r.populated_character_seed_sql().replace(str(owner), str(corpse_owner))
+body_seed = body_seed.replace(str(r.ACCOUNT_ID), str(r.ACCOUNT_ID + 1)).replace(r.CHARACTER_NAME, 'Planbody')
+r.mysql(m, g, body_seed, characters)
+q = f'DELETE FROM character_inventory WHERE guid={owner};'
+q += f'DELETE FROM item_instance WHERE guid IN ({bag},{food},{sword});'
+q += 'INSERT INTO item_instance (guid,itemEntry,owner_guid,count,durability,charges,enchantments) VALUES '
+q += ','.join(f"({guid},{entry},{owner},{quantity},{durability},'0 0 0 0 0 ','{'0 ' * 36}')"
+    for guid, entry, quantity, durability in [(bag,4496,1,0),(food,117,2,0),(sword,25,1,13)]) + ';'
+q += 'INSERT INTO character_inventory (guid,bag,slot,item) VALUES '
+q += f'({owner},0,19,{bag}),({owner},{bag},0,{food}),({owner},{bag},1,{sword});'
+q += migration
+q += f'DELETE FROM corpse WHERE guid={corpse_owner};'
+q += ('INSERT INTO corpse '
+    '(guid,posX,posY,posZ,orientation,mapId,displayId,itemCache,bytes1,guildId,flags,time,corpseType) ')
+q += f"VALUES ({corpse_owner},{x+3},{y+2},{z},1.5,0,49,'{'0 ' * 19}',256,123,4,UNIX_TIMESTAMP(),1);"
+q += f'DELETE FROM character_aura WHERE guid={owner} AND spell=50247;'
+q += 'INSERT INTO character_aura (guid,casterGuid,spell,effectMask,recalculateMask,stackCount,maxDuration,remainTime) '
+# The loaded tick counter derives from remaining time; a full duration exhausts the trigger budget.
+q += f'VALUES ({owner},{owner},50247,1,0,1,900000,450000);'
+q += f'UPDATE characters SET logout_time=UNIX_TIMESTAMP() WHERE guid={owner};'
+r.mysql(m, g, q, characters)
+r.mysql(m, g,
+    'DELETE FROM gameobject WHERE guid=9000000 AND id=2843;'
+    'INSERT INTO gameobject (guid,id,map,position_x,position_y,position_z,rotation3,spawntimesecs,animprogress,state) '
+    f'VALUES (9000000,2843,0,{x+3},{y-2},{z},1,300,255,1);', world)
+assert r.character_row_count(m, g) == 1
+assert r.mysql(m, g,
+    f'SELECT COUNT(*) FROM item_instance WHERE owner_guid={owner} '
+    "AND LENGTH(TRIM(enchantments))-LENGTH(REPLACE(TRIM(enchantments),' ',''))=44;", characters) == '3'
+# Existing log path records the ordinary aura trigger; it adds no server test hook.
+p = Path(g['paths']['world_config'])
+p.write_text(p.read_text() + '\nLogger.spells.aura = 5,Server\n')
+interface = Path(g['paths']['client']) / 'Interface'
+r.require_owned_path(interface.parent, g)
+if interface.is_symlink():
+    interface.unlink()  # Detach only our overlay link; never write into the protected client.
+interface.mkdir(exist_ok=True)
+r.require_owned_path(interface, g)
+addon = interface / 'AddOns/Plan18Evidence'
+addon.mkdir(parents=True, exist_ok=True)
+(addon / 'Plan18Evidence.toc').write_text('## Interface: 40300\n## Title: Plan 18 evidence\nPlan18Evidence.lua\n')
+(addon / 'Plan18Evidence.lua').write_text('''local frame = CreateFrame("Frame", nil, UIParent)
+frame:SetSize(500, 50)
+frame:SetPoint("TOPLEFT", 20, -130)
+local text = frame:CreateFontString(nil, "OVERLAY", "GameFontNormalLarge")
+text:SetAllPoints()
+text:SetJustifyH("LEFT")
+local elapsed = 0
+local opened = false
+frame:SetScript("OnUpdate", function(self, dt)
+  elapsed = elapsed + dt
+  if elapsed < 0.5 then return end
+  elapsed = 0
+  local _, count = GetContainerItemInfo(1, 1)
+  local bag = GetContainerNumSlots(1)
+  local food = GetContainerItemID(1, 1)
+  local sword = GetContainerItemID(1, 2)
+  local current, maximum = GetContainerItemDurability(1, 2)
+  local pass = bag == 6 and food == 117 and count == 2 and sword == 25 and current == 13 and maximum == 20
+  if pass and not opened then OpenAllBags(); opened = true end
+  text:SetText((pass and "PLAN 18 INVENTORY PASS" or "PLAN 18 INVENTORY WAIT") ..
+    "\\nSlots " .. tostring(bag) .. ", item " .. tostring(food) .. " x" .. tostring(count) ..
+    ", durability " .. tostring(current) .. "/" .. tostring(maximum))
+end)
+frame:RegisterEvent("PLAYER_ENTERING_WORLD")
+frame:SetScript("OnEvent", function() OpenAllBags() end)
+''')
+result = {'generation': g['number'], 'migration_idempotent': True, 'legacy_words': 36, 'cata_words': 45,
+    'bag_entry': 4496, 'bag_slots': 6, 'item_entries': [117, 25], 'durability': [13, 20],
+    'gameobject_entry': 2843, 'corpse_owner': corpse_owner, 'corpse_display': 49,
+    'aura': 50247, 'ground_spell': 50249, 'ground_visual': 11030}
+(Path(g['paths']['raw_evidence']).parent / 'plan18-fixture.json').write_text(json.dumps(result, indent=2) + '\n')
+print(json.dumps(result))

--- a/data/sql/updates/pending_db_characters/rev_1788937529456601782.sql
+++ b/data/sql/updates/pending_db_characters/rev_1788937529456601782.sql
@@ -1,0 +1,8 @@
+-- Cataclysm reserves slots 7-9; move the five WotLK property enchantments to slots 10-14.
+-- Match only the old 36-word representation so rerunning the update leaves Cata rows alone.
+UPDATE `item_instance` SET `enchantments` =
+    CONCAT(SUBSTRING_INDEX(TRIM(`enchantments`), ' ', 21),
+        ' 0 0 0 0 0 0 0 0 0 ',
+        SUBSTRING_INDEX(TRIM(`enchantments`), ' ', -15), ' ')
+WHERE
+    LENGTH(TRIM(`enchantments`)) - LENGTH(REPLACE(TRIM(`enchantments`), ' ', '')) = 35;

--- a/plan/18-item-container-gameobject-update-fields.md
+++ b/plan/18-item-container-gameobject-update-fields.md
@@ -1,23 +1,11 @@
-# Plan 18: Item/Container/GameObject/DynamicObject/Corpse update-fields Cata conversion
+# Plan 18: remaining object update fields
 
-Canonical issue: [#37](https://github.com/trolloks/azerothcore-cata/issues/37)
+Canonical issue: [#37](https://github.com/trolloks/azerothcore-cata/issues/37).
 
-Status: blocked by #36 (Plan 17); not blocking. Continues the "Object model" plan family started by
-Plan 17, converting the remaining `UpdateFields.h` boundaries -- `ITEM_END`, `CONTAINER_END`,
-`GAMEOBJECT_END`, `DYNAMICOBJECT_END`, `CORPSE_END` and every field offset inside them -- from their
-current WotLK layout to the real build 15595 layout, using the same reference sources as Plan 17
-(pinned TrinityCore commit `c699217775d90794158422387b07a917e161b582`, corroborated by `cata-js`).
+Status: implemented and validated; awaiting PR merge. The acceptance record lives in the issue.
 
-Deliberately split out of Plan 17 because none of these object types gate the player's own
-login/create block or the 90% loading-screen hang Plan 14 is blocked on -- items, containers,
-gameobjects, dynamic objects, and corpses only matter once the player can see and interact with them
-in the world, which requires Plan 17's fix to land first. Keeping this separate lets Plan 17 stay
-small and reviewable instead of a single conversion touching the entire update-fields table at once.
-
-## Acceptance
-
-- Every boundary and field offset in scope matches the pinned TrinityCore reference exactly.
-- `worldserver` builds clean with the renumbered fields.
-- A real build 15595 client correctly displays at least one of each affected object type it can
-  currently be made to encounter (an item in inventory, a lootable corpse, a gameobject, a dynamic
-  object such as a ground-targeted spell effect) without visible corruption or client-side rejection.
+The reusable isolated-client fixture is `apps/cata/seed_remaining_object_fields.py`. After preparing
+an `in-world-control-bootstrap` generation, pass its manifest to the helper, then use the existing
+runner. Open the equipped Small Brown Pouch manually and check the sword and jerky, the inventory
+overlay, nearby chest, player corpse, and ground flames. Follow `plan/client-automation.md` for
+isolation, capture, verification, and reset. Reuse the prepared database and built binaries.

--- a/plan/20-opcode-table-cata-realignment.md
+++ b/plan/20-opcode-table-cata-realignment.md
@@ -1,64 +1,7 @@
-# Plan 20: full opcode-table realignment to Cata 4.3.4
+# Plan 20: opcode-table Cataclysm realignment
 
-Canonical issue: [#41](https://github.com/trolloks/azerothcore-cata/issues/41)
+Canonical issue: [#41](https://github.com/trolloks/azerothcore-cata/issues/41).
 
-Status: blocks #32 (Plan 14). The last measured blocker preventing the real build 15595
-client from completing world entry.
-
-## The problem, measured
-
-Diffing this fork's `src/server/game/Server/Protocol/Opcodes.h` against the pinned
-Cataclysm TrinityCore reference (`c699217775d90794158422387b07a917e161b582`) by opcode
-name:
-
-- 884 opcode names exist in both tables
-- **714 of them still carry WotLK numeric values**
-- **367 of those are `SMSG_` server-to-client responses**
-
-This is directly observable on the wire. In the latest real-client run the client's
-requests all arrive on correct Cata values, and the server answers on WotLK values the
-client cannot recognise:
-
-| Response we send | Ours | TrinityCore (Cata) |
-| --- | --- | --- |
-| `SMSG_QUERY_TIME_RESPONSE` | `0x01CF` | (per reference) |
-| `SMSG_PLAYED_TIME` | `0x01CD` | (per reference) |
-| `SMSG_RAID_INSTANCE_INFO` | `0x02CC` | (per reference) |
-| `SMSG_GAMEOBJECT_QUERY_RESPONSE` | `0x0915` | (per reference) |
-
-The client visibly retries (`CMSG_QUERY_TIME` is sent twice in a single run), which is the
-signature of a request whose answer never arrives in a recognisable form. `SMSG_NAME_QUERY_RESPONSE`
-was one instance of exactly this class and fixing it alone (WotLK `0x051` → Cata `0x6E04`)
-measurably advanced the client, so the remainder are expected to behave the same way.
-
-## Approach
-
-Adopt the pinned TrinityCore value for every opcode name present in both tables. This is
-mechanical, not a judgement call: TrinityCore's Cata table is the authority for build 15595
-and is already this repo's designated priority-2 reference.
-
-Two things to handle deliberately:
-
-1. **Collisions.** Adopting TrinityCore's values raises same-direction opcode collisions
-   from 5 to 15. Every new collision is between dead WotLK leftovers that TrinityCore does
-   not define at all (`CMSG_CHEAT_SETMONEY`, `CMSG_LEVEL_CHEAT`, `CMSG_BOT_DETECTED2`,
-   commentator/GM opcodes) and a legitimately-renumbered opcode. `OpcodeTable::ValidateAndSet*`
-   logs an error and keeps the first registration rather than crashing, so these are
-   non-fatal, but they should be resolved rather than tolerated -- prefer removing the dead
-   WotLK-only opcodes over leaving duplicate registrations.
-2. **The `/*0xNNN*/` comments** in `Opcodes.cpp` become stale. They are cosmetic (the
-   registration macros key off the enum name) but should be regenerated for readability.
-
-Out of scope: opcodes this fork defines that TrinityCore does not, and opcodes TrinityCore
-defines that this fork lacks. Both are separate follow-ups; this plan only corrects values
-for names that already exist in both.
-
-## Acceptance
-
-- Every shared opcode name matches the pinned TrinityCore value.
-- No new same-direction collisions remain; `worldserver` starts with no
-  "Tried to override ... handler" errors in the log.
-- `worldserver`/`authserver` build clean.
-- A real build 15595 client run reaches the in-world-control marker
-  (`CMSG_TIME_SYNC_RESP` observed, satisfying Plan 13's criterion in #27) and dismisses the
-  loading screen, across two consecutive clean runs.
+Status: complete. PR #42 converted the table; the accepted real-client run in PR #50 supplied the
+remaining world-entry evidence. The closure audit found all 894 shared values matched the pinned
+reference, no assigned same-direction CMSG/SMSG collisions, and no runtime handler overrides.

--- a/plan/github-issues.tsv
+++ b/plan/github-issues.tsv
@@ -9,10 +9,14 @@ plan	issue	state	title	url
 08	18	closed	Plan 8: typed empty character enumeration and stable build 15595 screen	https://github.com/trolloks/azerothcore-cata/issues/18
 09	19	closed	Plan 9: one database-backed build 15595 character	https://github.com/trolloks/azerothcore-cata/issues/19
 10	20	closed	Plan 10: select the enumerated build 15595 character	https://github.com/trolloks/azerothcore-cata/issues/20
-11	25	closed	Plan 11: build 15595 initial post-load packet contract	https://github.com/trolloks/azerothcore-cata/issues/25
+11	25	closed	Plan 11: build 15595 pre-map initial-packet contract	https://github.com/trolloks/azerothcore-cata/issues/25
 12	26	closed	Plan 12: build 15595 map insertion and object bootstrap	https://github.com/trolloks/azerothcore-cata/issues/26
 13	27	closed	Plan 13: build 15595 in-world control bootstrap	https://github.com/trolloks/azerothcore-cata/issues/27
 14	32	closed	Plan 14: build 15595 post-map-insertion client survival	https://github.com/trolloks/azerothcore-cata/issues/32
-15	33	open	Plan 15: build 15595 basic movement packet contract	https://github.com/trolloks/azerothcore-cata/issues/33
-16	34	open	Plan 16: build 15595 movement acknowledgement and speed contract	https://github.com/trolloks/azerothcore-cata/issues/34
+15	33	closed	Plan 15: build 15595 basic movement packet contract	https://github.com/trolloks/azerothcore-cata/issues/33
+16	34	closed	Plan 16: build 15595 movement acknowledgement and speed contract	https://github.com/trolloks/azerothcore-cata/issues/34
+17	36	closed	Plan 17: Object/Unit/Player update-fields Cata conversion	https://github.com/trolloks/azerothcore-cata/issues/36
+18	37	open	Plan 18: Item/Container/GameObject/DynamicObject/Corpse update-fields Cata conversion	https://github.com/trolloks/azerothcore-cata/issues/37
+19	40	closed	Plan 19: bit-packed movement/create block Cata conversion	https://github.com/trolloks/azerothcore-cata/issues/40
+20	41	closed	Plan 20: full opcode-table realignment to Cata 4.3.4	https://github.com/trolloks/azerothcore-cata/issues/41
 21	43	closed	Plan 21: login packet sequence parity with cata-js	https://github.com/trolloks/azerothcore-cata/issues/43

--- a/src/server/game/Entities/Corpse/Corpse.cpp
+++ b/src/server/game/Entities/Corpse/Corpse.cpp
@@ -81,6 +81,7 @@ bool Corpse::Create(ObjectGuid::LowType guidlow, Player* owner)
 
     SetObjectScale(1);
     SetGuidValue(CORPSE_FIELD_OWNER, owner->GetGUID());
+    _guildId = owner->GetGuildId();
 
     _cellCoord = Acore::ComputeCellCoord(GetPositionX(), GetPositionY());
 
@@ -104,7 +105,7 @@ void Corpse::SaveToDB()
     stmt->SetData(7, _ConcatFields(CORPSE_FIELD_ITEM, EQUIPMENT_SLOT_END));   // itemCache
     stmt->SetData(8, GetUInt32Value(CORPSE_FIELD_BYTES_1));                   // bytes1
     stmt->SetData(9, GetUInt32Value(CORPSE_FIELD_BYTES_2));                   // bytes2
-    stmt->SetData(10, GetUInt32Value(CORPSE_FIELD_GUILD));                    // guildId
+    stmt->SetData(10, _guildId);                                            // guildId
     stmt->SetData (11, GetUInt32Value(CORPSE_FIELD_FLAGS));                    // flags
     stmt->SetData (12, GetUInt32Value(CORPSE_FIELD_DYNAMIC_FLAGS));            // dynFlags
     stmt->SetData(13, uint32(m_time));                                        // time
@@ -153,7 +154,7 @@ bool Corpse::LoadCorpseFromDB(ObjectGuid::LowType guid, Field* fields)
 
     SetUInt32Value(CORPSE_FIELD_BYTES_1, fields[7].Get<uint32>());
     SetUInt32Value(CORPSE_FIELD_BYTES_2, fields[8].Get<uint32>());
-    SetUInt32Value(CORPSE_FIELD_GUILD, fields[9].Get<uint32>());
+    _guildId = fields[9].Get<uint32>();
     SetUInt32Value(CORPSE_FIELD_FLAGS, fields[10].Get<uint8>());
     SetUInt32Value(CORPSE_FIELD_DYNAMIC_FLAGS, fields[11].Get<uint8>());
     SetGuidValue(CORPSE_FIELD_OWNER, ObjectGuid::Create<HighGuid::Player>(ownerGuid));

--- a/src/server/game/Entities/Corpse/Corpse.h
+++ b/src/server/game/Entities/Corpse/Corpse.h
@@ -81,6 +81,7 @@ public:
 
 private:
     CorpseType m_type;
+    uint32 _guildId = 0; // Persisted server data; not a Cataclysm update field.
     time_t m_time;
     CellCoord _cellCoord;
 };

--- a/src/server/game/Entities/DynamicObject/DynamicObject.cpp
+++ b/src/server/game/Entities/DynamicObject/DynamicObject.cpp
@@ -94,13 +94,15 @@ void DynamicObject::RemoveFromWorld()
     }
 }
 
-bool DynamicObject::CreateDynamicObject(ObjectGuid::LowType guidlow, Unit* caster, uint32 spellId, Position const& pos, float radius, DynamicObjectType type)
+bool DynamicObject::CreateDynamicObject(ObjectGuid::LowType guidlow, Unit* caster, SpellInfo const* spellInfo,
+    Position const& pos, float radius, DynamicObjectType type)
 {
     SetMap(caster->GetMap());
     Relocate(pos);
     if (!IsPositionValid())
     {
-        LOG_ERROR("dyobject", "DynamicObject (spell {}) not created. Suggested coordinates isn't valid (X: {} Y: {})", spellId, GetPositionX(), GetPositionY());
+        LOG_ERROR("dyobject", "DynamicObject (spell {}) not created. Invalid coordinates (X: {} Y: {})",
+            spellInfo->Id, GetPositionX(), GetPositionY());
         return false;
     }
 
@@ -108,17 +110,12 @@ bool DynamicObject::CreateDynamicObject(ObjectGuid::LowType guidlow, Unit* caste
 
     UpdatePositionData();
 
-    SetEntry(spellId);
+    SetEntry(spellInfo->Id);
     SetObjectScale(1);
     SetGuidValue(DYNAMICOBJECT_CASTER, caster->GetGUID());
 
-    // The lower word of DYNAMICOBJECT_BYTES must be 0x0001. This value means that the visual radius will be overriden
-    // by client for most of the "ground patch" visual effect spells and a few "skyfall" ones like Hurricane.
-    // If any other value is used, the client will _always_ use the radius provided in DYNAMICOBJECT_RADIUS, but
-    // precompensation is necessary (eg radius *= 2) for many spells. Anyway, blizz sends 0x0001 for all the spells
-    // I saw sniffed...
-    SetByteValue(DYNAMICOBJECT_BYTES, 0, type);
-    SetUInt32Value(DYNAMICOBJECT_SPELLID, spellId);
+    SetUInt32Value(DYNAMICOBJECT_BYTES, spellInfo->SpellVisual[0] | (uint32(type) << 28));
+    SetUInt32Value(DYNAMICOBJECT_SPELLID, spellInfo->Id);
     SetFloatValue(DYNAMICOBJECT_RADIUS, radius);
     SetUInt32Value(DYNAMICOBJECT_CASTTIME, GameTime::GetGameTimeMS().count());
 
@@ -275,7 +272,7 @@ void DynamicObject::UnbindFromCaster()
 
 bool DynamicObject::IsUpdateNeeded()
 {
-    if (GetByteValue(DYNAMICOBJECT_BYTES, 0) == DYNAMIC_OBJECT_AREA_SPELL)
+    if ((GetUInt32Value(DYNAMICOBJECT_BYTES) >> 28) == DYNAMIC_OBJECT_AREA_SPELL)
         return true;
 
     return WorldObject::IsUpdateNeeded();

--- a/src/server/game/Entities/DynamicObject/DynamicObject.h
+++ b/src/server/game/Entities/DynamicObject/DynamicObject.h
@@ -42,7 +42,8 @@ public:
 
     void CleanupsBeforeDelete(bool finalCleanup = true) override;
 
-    bool CreateDynamicObject(ObjectGuid::LowType guidlow, Unit* caster, uint32 spellId, Position const& pos, float radius, DynamicObjectType type);
+    bool CreateDynamicObject(ObjectGuid::LowType guidlow, Unit* caster, SpellInfo const* spellInfo,
+        Position const& pos, float radius, DynamicObjectType type);
     void Update(uint32 p_time) override;
     void Remove();
     void SetDuration(int32 newDuration);

--- a/src/server/game/Entities/Item/Item.h
+++ b/src/server/game/Entities/Item/Item.h
@@ -173,14 +173,17 @@ enum EnchantmentSlot : uint8
     SOCK_ENCHANTMENT_SLOT_3         = 4,
     BONUS_ENCHANTMENT_SLOT          = 5,
     PRISMATIC_ENCHANTMENT_SLOT      = 6,                    // added at apply special permanent enchantment
-    MAX_INSPECTED_ENCHANTMENT_SLOT  = 7,
+    // Slot 7 is reserved by the client.
+    REFORGE_ENCHANTMENT_SLOT        = 8,
+    TRANSMOGRIFY_ENCHANTMENT_SLOT   = 9,
+    MAX_INSPECTED_ENCHANTMENT_SLOT  = 10,
 
-    PROP_ENCHANTMENT_SLOT_0         = 7,                    // used with RandomSuffix and RandomProperty
-    PROP_ENCHANTMENT_SLOT_1         = 8,                    // used with RandomSuffix and RandomProperty
-    PROP_ENCHANTMENT_SLOT_2         = 9,                    // used with RandomSuffix and RandomProperty
-    PROP_ENCHANTMENT_SLOT_3         = 10,                   // used with RandomSuffix and RandomProperty
-    PROP_ENCHANTMENT_SLOT_4         = 11,                   // used with RandomSuffix and RandomProperty
-    MAX_ENCHANTMENT_SLOT            = 12
+    PROP_ENCHANTMENT_SLOT_0         = 10,                    // used with RandomSuffix and RandomProperty
+    PROP_ENCHANTMENT_SLOT_1         = 11,                    // used with RandomSuffix and RandomProperty
+    PROP_ENCHANTMENT_SLOT_2         = 12,                    // used with RandomSuffix and RandomProperty
+    PROP_ENCHANTMENT_SLOT_3         = 13,                   // used with RandomSuffix and RandomProperty
+    PROP_ENCHANTMENT_SLOT_4         = 14,                   // used with RandomSuffix and RandomProperty
+    MAX_ENCHANTMENT_SLOT            = 15
 };
 
 #define MAX_VISIBLE_ITEM_OFFSET       2                     // 2 fields per visible item (entry+enchantment)

--- a/src/server/game/Entities/Object/Updates/UpdateFieldFlags.cpp
+++ b/src/server/game/Entities/Object/Updates/UpdateFieldFlags.cpp
@@ -79,12 +79,20 @@ uint32 ItemUpdateFieldFlags[CONTAINER_END] =
     UF_FLAG_PUBLIC,                                         // ITEM_FIELD_ENCHANTMENT_12_1
     UF_FLAG_PUBLIC,                                         // ITEM_FIELD_ENCHANTMENT_12_1+1
     UF_FLAG_PUBLIC,                                         // ITEM_FIELD_ENCHANTMENT_12_3
+    UF_FLAG_PUBLIC,                                         // ITEM_FIELD_ENCHANTMENT_13_1
+    UF_FLAG_PUBLIC,                                         // ITEM_FIELD_ENCHANTMENT_13_1+1
+    UF_FLAG_PUBLIC,                                         // ITEM_FIELD_ENCHANTMENT_13_3
+    UF_FLAG_PUBLIC,                                         // ITEM_FIELD_ENCHANTMENT_14_1
+    UF_FLAG_PUBLIC,                                         // ITEM_FIELD_ENCHANTMENT_14_1+1
+    UF_FLAG_PUBLIC,                                         // ITEM_FIELD_ENCHANTMENT_14_3
+    UF_FLAG_PUBLIC,                                         // ITEM_FIELD_ENCHANTMENT_15_1
+    UF_FLAG_PUBLIC,                                         // ITEM_FIELD_ENCHANTMENT_15_1+1
+    UF_FLAG_PUBLIC,                                         // ITEM_FIELD_ENCHANTMENT_15_3
     UF_FLAG_PUBLIC,                                         // ITEM_FIELD_PROPERTY_SEED
     UF_FLAG_PUBLIC,                                         // ITEM_FIELD_RANDOM_PROPERTIES_ID
     UF_FLAG_OWNER | UF_FLAG_ITEM_OWNER,                     // ITEM_FIELD_DURABILITY
     UF_FLAG_OWNER | UF_FLAG_ITEM_OWNER,                     // ITEM_FIELD_MAXDURABILITY
     UF_FLAG_PUBLIC,                                         // ITEM_FIELD_CREATE_PLAYED_TIME
-    UF_FLAG_NONE,                                           // ITEM_FIELD_PAD
     UF_FLAG_PUBLIC,                                         // CONTAINER_FIELD_NUM_SLOTS
     UF_FLAG_NONE,                                           // CONTAINER_ALIGN_PAD
     UF_FLAG_PUBLIC,                                         // CONTAINER_FIELD_SLOT_1
@@ -1585,7 +1593,7 @@ uint32 DynamicObjectUpdateFieldFlags[DYNAMICOBJECT_END] =
     UF_FLAG_NONE,                                           // OBJECT_FIELD_PADDING
     UF_FLAG_PUBLIC,                                         // DYNAMICOBJECT_CASTER
     UF_FLAG_PUBLIC,                                         // DYNAMICOBJECT_CASTER+1
-    UF_FLAG_PUBLIC,                                         // DYNAMICOBJECT_BYTES
+    UF_FLAG_DYNAMIC,                                        // DYNAMICOBJECT_BYTES
     UF_FLAG_PUBLIC,                                         // DYNAMICOBJECT_SPELLID
     UF_FLAG_PUBLIC,                                         // DYNAMICOBJECT_RADIUS
     UF_FLAG_PUBLIC,                                         // DYNAMICOBJECT_CASTTIME
@@ -1627,8 +1635,6 @@ uint32 CorpseUpdateFieldFlags[CORPSE_END] =
     UF_FLAG_PUBLIC,                                         // CORPSE_FIELD_ITEM+18
     UF_FLAG_PUBLIC,                                         // CORPSE_FIELD_BYTES_1
     UF_FLAG_PUBLIC,                                         // CORPSE_FIELD_BYTES_2
-    UF_FLAG_PUBLIC,                                         // CORPSE_FIELD_GUILD
     UF_FLAG_PUBLIC,                                         // CORPSE_FIELD_FLAGS
     UF_FLAG_DYNAMIC,                                        // CORPSE_FIELD_DYNAMIC_FLAGS
-    UF_FLAG_NONE,                                           // CORPSE_FIELD_PAD
 };

--- a/src/server/game/Entities/Object/Updates/UpdateFields.h
+++ b/src/server/game/Entities/Object/Updates/UpdateFields.h
@@ -18,14 +18,8 @@
 #ifndef _UPDATEFIELDS_AUTO_H
 #define _UPDATEFIELDS_AUTO_H
 
-// Auto generated for version 3, 3, 5, 12340
-//
-// EObjectFields, EUnitFields, and EPlayerFields were replaced with the equivalent blocks from
-// the pinned Cata 4.3.4 build 15595 TrinityCore reference (commit c699217775d90794158422387b07a917e161b582)
-// as part of Plan 17 (github.com/trolloks/azerothcore-cata/issues/36). EItemFields, EContainerFields,
-// EGameObjectFields, EDynamicObjectFields, and ECorpseFields are still the original WotLK 3.3.5.12340
-// layout, deferred to Plan 18 (issues/37) -- they are automatically re-anchored to the new OBJECT_END
-// value but their own internal field offsets have not been converted yet.
+// Update fields for Cataclysm 4.3.4 build 15595, from TrinityCore
+// c699217775d90794158422387b07a917e161b582. See conversion issues #36 and #37.
 
 enum EObjectFields
 {
@@ -37,7 +31,6 @@ enum EObjectFields
     OBJECT_FIELD_PADDING                             = 0x0007, // Size: 1, Type: INT, Flags: NONE
     OBJECT_END                                       = 0x0008
 };
-
 
 enum EItemFields
 {
@@ -73,13 +66,18 @@ enum EItemFields
     ITEM_FIELD_ENCHANTMENT_11_3               = OBJECT_END + 0x0030, // Size: 1, Type: TWO_SHORT, Flags: PUBLIC
     ITEM_FIELD_ENCHANTMENT_12_1               = OBJECT_END + 0x0031, // Size: 2, Type: INT, Flags: PUBLIC
     ITEM_FIELD_ENCHANTMENT_12_3               = OBJECT_END + 0x0033, // Size: 1, Type: TWO_SHORT, Flags: PUBLIC
-    ITEM_FIELD_PROPERTY_SEED                  = OBJECT_END + 0x0034, // Size: 1, Type: INT, Flags: PUBLIC
-    ITEM_FIELD_RANDOM_PROPERTIES_ID           = OBJECT_END + 0x0035, // Size: 1, Type: INT, Flags: PUBLIC
-    ITEM_FIELD_DURABILITY                     = OBJECT_END + 0x0036, // Size: 1, Type: INT, Flags: OWNER, ITEM_OWNER
-    ITEM_FIELD_MAXDURABILITY                  = OBJECT_END + 0x0037, // Size: 1, Type: INT, Flags: OWNER, ITEM_OWNER
-    ITEM_FIELD_CREATE_PLAYED_TIME             = OBJECT_END + 0x0038, // Size: 1, Type: INT, Flags: PUBLIC
-    ITEM_FIELD_PAD                            = OBJECT_END + 0x0039, // Size: 1, Type: INT, Flags: NONE
-    ITEM_END                                  = OBJECT_END + 0x003A,
+    ITEM_FIELD_ENCHANTMENT_13_1               = OBJECT_END + 0x0034, // Size: 2, Type: INT, Flags: PUBLIC
+    ITEM_FIELD_ENCHANTMENT_13_3               = OBJECT_END + 0x0036, // Size: 1, Type: TWO_SHORT, Flags: PUBLIC
+    ITEM_FIELD_ENCHANTMENT_14_1               = OBJECT_END + 0x0037, // Size: 2, Type: INT, Flags: PUBLIC
+    ITEM_FIELD_ENCHANTMENT_14_3               = OBJECT_END + 0x0039, // Size: 1, Type: TWO_SHORT, Flags: PUBLIC
+    ITEM_FIELD_ENCHANTMENT_15_1               = OBJECT_END + 0x003A, // Size: 2, Type: INT, Flags: PUBLIC
+    ITEM_FIELD_ENCHANTMENT_15_3               = OBJECT_END + 0x003C, // Size: 1, Type: TWO_SHORT, Flags: PUBLIC
+    ITEM_FIELD_PROPERTY_SEED                  = OBJECT_END + 0x003D, // Size: 1, Type: INT, Flags: PUBLIC
+    ITEM_FIELD_RANDOM_PROPERTIES_ID           = OBJECT_END + 0x003E, // Size: 1, Type: INT, Flags: PUBLIC
+    ITEM_FIELD_DURABILITY                     = OBJECT_END + 0x003F, // Size: 1, Type: INT, Flags: OWNER, ITEM_OWNER
+    ITEM_FIELD_MAXDURABILITY                  = OBJECT_END + 0x0040, // Size: 1, Type: INT, Flags: OWNER, ITEM_OWNER
+    ITEM_FIELD_CREATE_PLAYED_TIME             = OBJECT_END + 0x0041, // Size: 1, Type: INT, Flags: PUBLIC
+    ITEM_END                                  = OBJECT_END + 0x0042,
 };
 
 enum EContainerFields
@@ -87,7 +85,7 @@ enum EContainerFields
     CONTAINER_FIELD_NUM_SLOTS                 = ITEM_END + 0x0000, // Size: 1, Type: INT, Flags: PUBLIC
     CONTAINER_ALIGN_PAD                       = ITEM_END + 0x0001, // Size: 1, Type: BYTES, Flags: NONE
     CONTAINER_FIELD_SLOT_1                    = ITEM_END + 0x0002, // Size: 72, Type: LONG, Flags: PUBLIC
-    CONTAINER_END                             = ITEM_END + 0x004A,
+    CONTAINER_END                             = ITEM_END + 0x004A
 };
 
 enum EUnitFields
@@ -183,7 +181,6 @@ enum EUnitFields
     UNIT_FIELD_PADDING                               = OBJECT_END + 0x0089, // Size: 1, Type: INT, Flags: NONE
     UNIT_END                                         = OBJECT_END + 0x008A
 };
-
 
 enum EPlayerFields
 {
@@ -520,7 +517,6 @@ enum EPlayerFields
     PLAYER_END                                       = UNIT_END + 0x04D6
 };
 
-
 enum EGameObjectFields
 {
     OBJECT_FIELD_CREATED_BY                   = OBJECT_END + 0x0000, // Size: 2, Type: LONG, Flags: PUBLIC
@@ -531,17 +527,17 @@ enum EGameObjectFields
     GAMEOBJECT_FACTION                        = OBJECT_END + 0x0009, // Size: 1, Type: INT, Flags: PUBLIC
     GAMEOBJECT_LEVEL                          = OBJECT_END + 0x000A, // Size: 1, Type: INT, Flags: PUBLIC
     GAMEOBJECT_BYTES_1                        = OBJECT_END + 0x000B, // Size: 1, Type: BYTES, Flags: PUBLIC
-    GAMEOBJECT_END                            = OBJECT_END + 0x000C,
+    GAMEOBJECT_END                            = OBJECT_END + 0x000C
 };
 
 enum EDynamicObjectFields
 {
     DYNAMICOBJECT_CASTER                      = OBJECT_END + 0x0000, // Size: 2, Type: LONG, Flags: PUBLIC
-    DYNAMICOBJECT_BYTES                       = OBJECT_END + 0x0002, // Size: 1, Type: BYTES, Flags: PUBLIC
+    DYNAMICOBJECT_BYTES                       = OBJECT_END + 0x0002, // Size: 1, Type: INT, Flags: DYNAMIC
     DYNAMICOBJECT_SPELLID                     = OBJECT_END + 0x0003, // Size: 1, Type: INT, Flags: PUBLIC
     DYNAMICOBJECT_RADIUS                      = OBJECT_END + 0x0004, // Size: 1, Type: FLOAT, Flags: PUBLIC
     DYNAMICOBJECT_CASTTIME                    = OBJECT_END + 0x0005, // Size: 1, Type: INT, Flags: PUBLIC
-    DYNAMICOBJECT_END                         = OBJECT_END + 0x0006,
+    DYNAMICOBJECT_END                         = OBJECT_END + 0x0006
 };
 
 enum ECorpseFields
@@ -552,10 +548,8 @@ enum ECorpseFields
     CORPSE_FIELD_ITEM                         = OBJECT_END + 0x0005, // Size: 19, Type: INT, Flags: PUBLIC
     CORPSE_FIELD_BYTES_1                      = OBJECT_END + 0x0018, // Size: 1, Type: BYTES, Flags: PUBLIC
     CORPSE_FIELD_BYTES_2                      = OBJECT_END + 0x0019, // Size: 1, Type: BYTES, Flags: PUBLIC
-    CORPSE_FIELD_GUILD                        = OBJECT_END + 0x001A, // Size: 1, Type: INT, Flags: PUBLIC
-    CORPSE_FIELD_FLAGS                        = OBJECT_END + 0x001B, // Size: 1, Type: INT, Flags: PUBLIC
-    CORPSE_FIELD_DYNAMIC_FLAGS                = OBJECT_END + 0x001C, // Size: 1, Type: INT, Flags: DYNAMIC
-    CORPSE_FIELD_PAD                          = OBJECT_END + 0x001D, // Size: 1, Type: INT, Flags: NONE
-    CORPSE_END                                = OBJECT_END + 0x001E,
+    CORPSE_FIELD_FLAGS                        = OBJECT_END + 0x001A, // Size: 1, Type: INT, Flags: PUBLIC
+    CORPSE_FIELD_DYNAMIC_FLAGS                = OBJECT_END + 0x001B, // Size: 1, Type: INT, Flags: DYNAMIC
+    CORPSE_END                                = OBJECT_END + 0x001C
 };
 #endif

--- a/src/server/game/Entities/Player/Player.cpp
+++ b/src/server/game/Entities/Player/Player.cpp
@@ -4635,8 +4635,6 @@ Corpse* Player::CreateCorpse()
 
     corpse->SetUInt32Value(CORPSE_FIELD_DISPLAY_ID, GetNativeDisplayId());
 
-    corpse->SetUInt32Value(CORPSE_FIELD_GUILD, GetGuildId());
-
     uint32 iDisplayID;
     uint32 iIventoryType;
     uint32 _cfi;

--- a/src/server/game/Spells/SpellEffects.cpp
+++ b/src/server/game/Spells/SpellEffects.cpp
@@ -1864,7 +1864,8 @@ void Spell::EffectPersistentAA(SpellEffIndex effIndex)
         if (!caster->IsInWorld() || !caster->FindMap() || !ObjectAccessor::GetUnit(*caster, caster->GetGUID())) // pussywizard: temporary crash fix (FindMap and GetUnit are mine)
             return;
         DynamicObject* dynObj = new DynamicObject();
-        if (!dynObj->CreateDynamicObject(caster->GetMap()->GenerateLowGuid<HighGuid::DynamicObject>(), caster, m_spellInfo->Id, *destTarget, radius, DYNAMIC_OBJECT_AREA_SPELL))
+        if (!dynObj->CreateDynamicObject(caster->GetMap()->GenerateLowGuid<HighGuid::DynamicObject>(),
+            caster, m_spellInfo, *destTarget, radius, DYNAMIC_OBJECT_AREA_SPELL))
         {
             delete dynObj;
             return;
@@ -2757,7 +2758,8 @@ void Spell::EffectAddFarsight(SpellEffIndex effIndex)
     bool updateViewerVisibility = m_caster->RemoveDynObject(m_spellInfo->Id);
 
     DynamicObject* dynObj = new DynamicObject();
-    if (!dynObj->CreateDynamicObject(m_caster->GetMap()->GenerateLowGuid<HighGuid::DynamicObject>(), m_caster, m_spellInfo->Id, *destTarget, radius, DYNAMIC_OBJECT_FARSIGHT_FOCUS))
+    if (!dynObj->CreateDynamicObject(m_caster->GetMap()->GenerateLowGuid<HighGuid::DynamicObject>(),
+        m_caster, m_spellInfo, *destTarget, radius, DYNAMIC_OBJECT_FARSIGHT_FOCUS))
     {
         delete dynObj;
         return;

--- a/src/test/server/game/Entities/Object/UpdateFieldsTest.cpp
+++ b/src/test/server/game/Entities/Object/UpdateFieldsTest.cpp
@@ -1,0 +1,65 @@
+/*
+ * This file is part of the AzerothCore Project. See AUTHORS file for Copyright information
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by the
+ * Free Software Foundation; either version 2 of the License, or (at your
+ * option) any later version.
+ */
+
+#include "Bag.h"
+#include "DynamicObject.h"
+#include "UpdateFieldFlags.h"
+#include <gtest/gtest.h>
+#include <string>
+
+TEST(UpdateFieldsTest, LoadsAllEnchantmentsWithoutOverwritingItemOrBagFields)
+{
+    class TestBag : public Bag
+    {
+    public:
+        using Object::_InitValues;
+        using Object::_LoadIntoDataField;
+    } bag;
+    bag._InitValues();
+    bag.SetUInt32Value(ITEM_FIELD_DURABILITY, 39);
+    bag.SetUInt32Value(ITEM_FIELD_MAXDURABILITY, 40);
+    bag.SetUInt32Value(CONTAINER_FIELD_NUM_SLOTS, 1);
+    bag.SetGuidValue(CONTAINER_FIELD_SLOT_1, ObjectGuid::Create<HighGuid::Item>(123));
+
+    std::string enchants;
+    for (uint32 word = 1; word <= 45; ++word)
+        enchants += std::to_string(word) + " ";
+    ASSERT_TRUE(bag._LoadIntoDataField(enchants, ITEM_FIELD_ENCHANTMENT_1_1,
+        MAX_ENCHANTMENT_SLOT * MAX_ENCHANTMENT_OFFSET));
+    EXPECT_EQ(bag.GetEnchantmentId(PROP_ENCHANTMENT_SLOT_0), 31u);
+    EXPECT_EQ(bag.GetEnchantmentCharges(PROP_ENCHANTMENT_SLOT_4), 45u);
+    // Absolute build-15595 positions, independent of the server enum expressions.
+    EXPECT_EQ(bag.GetUInt32Value(0x44), 45u);
+    EXPECT_EQ(bag.GetUInt32Value(0x47), 39u);
+    EXPECT_EQ(bag.GetUInt32Value(0x48), 40u);
+    EXPECT_EQ(bag.GetUInt32Value(0x4A), 1u);
+    EXPECT_EQ(bag.GetGuidValue(0x4C), ObjectGuid::Create<HighGuid::Item>(123));
+    EXPECT_EQ(bag.GetValuesCount(), 0x94u);
+    EXPECT_EQ(ItemUpdateFieldFlags[0x44], UF_FLAG_PUBLIC);
+    EXPECT_EQ(ItemUpdateFieldFlags[0x47], UF_FLAG_OWNER | UF_FLAG_ITEM_OWNER);
+    EXPECT_EQ(ItemUpdateFieldFlags[0x48], UF_FLAG_OWNER | UF_FLAG_ITEM_OWNER);
+    EXPECT_EQ(ItemUpdateFieldFlags[0x4B], UF_FLAG_NONE);
+}
+
+TEST(UpdateFieldsTest, KeepsAreaSpellsUpdatingWithCataclysmVisualBits)
+{
+    class TestDynamicObject : public DynamicObject
+    {
+    public:
+        using Object::_InitValues;
+    } object;
+    object._InitValues();
+    // A visual whose low byte is not the old WotLK area-spell type byte.
+    object.SetUInt32Value(DYNAMICOBJECT_BYTES, 0x10001234);
+    EXPECT_TRUE(object.IsUpdateNeeded());
+    EXPECT_EQ(DynamicObjectUpdateFieldFlags[0x0A], UF_FLAG_DYNAMIC);
+    EXPECT_EQ(CorpseUpdateFieldFlags[0x22], UF_FLAG_PUBLIC);
+    EXPECT_EQ(CorpseUpdateFieldFlags[0x23], UF_FLAG_DYNAMIC);
+    EXPECT_EQ(CORPSE_END, 0x24);
+}


### PR DESCRIPTION
## Changes Proposed:

Convert the remaining item, container, gameobject, dynamic-object, and corpse field contracts to
build 15595. This fixes item-tail and bag offsets, moves random enchantments into the Cata slots,
and stops corpse guild IDs occupying a client field. Ground objects now carry the spell visual ID
and their type in the high four bits.

The pending character migration preserves the existing enchantment triples and adds the three
reserved slots. Corpse guild IDs remain in the existing database column as server data.

- [x] Core (units, players, creatures, game systems).
- [ ] Scripts (bosses, spell scripts, creature scripts).
- [x] Database (SAI, creatures, etc).

### AI-assisted Pull Requests

- [x] AI tools were used to prepare this pull request.
  - Codex, GPT-6, produced the implementation, checks, and description.
- [ ] I have read and understood the [AC guidelines for AI Agentic Engineering](https://www.azerothcore.org/wiki/agentic-engineering)

## Issues Addressed:

- Closes #37.
- Refreshes the plan index and records the independently verified closure of #41.

## SOURCE:

- [x] The changes come partially from another project and credit its authors.

[TrinityCore build-15595 field definitions](https://github.com/TrinityCore/TrinityCore/blob/c699217775d90794158422387b07a917e161b582/src/server/game/Entities/Object/Updates/UpdateFields.h),
visibility flags, enchantment slots, and dynamic-object visual encoding at the same pinned commit.
The implementation commit uses Shauren as author and credits ariel- as co-author. Item/container
fields also match cata-js `ab964a0e8dfe50a44fa92716ed05438f4a14dfd3`.

## Tests Performed:

- All 72 in-scope fields/end markers and all 218 visibility entries match the TrinityCore pin.
- C++ and SQL codestyle checks pass.
- One GCC 13 Release build of worldserver, authserver, and unit_tests passed at `0e06cf067`.
- 5,949 tests passed, including both new field checks; 5,487 skipped and one disabled. No failures.
- The migration passed five real-MySQL cases twice: legacy, converted, empty, partial, and legacy
  without trailing whitespace. Converted and partial values remain unchanged on repeat.
- Generation 86 stayed in-world for 30 seconds. The inventory overlay read six bag slots,
  two jerky, and sword durability 13/20. The user manually opened the bag and confirmed the
  blade and jerky. GNOME screenshots show the chest, player corpse, and ground flames;
  the ordinary aura path logged 97 triggers of ground spell 50249.
- One build and one cached database prepare served two client attempts. The first fixture had
  an exhausted saved-aura tick budget; correcting its remaining duration required only a client
  retry. No third run followed the user's confirmation.
- The generic verifier retained its earlier INCONCLUSIVE verdict because screen confirmation
  arrived afterward. Supplemental acceptance records the human confirmation and artifact hashes;
  the original evidence/state was preserved. Reset passed, with protected inputs unchanged.

Self-review at `277fbcc3e`: no findings. Only the reusable fixture and plan records changed after
compiled commit `0e06cf067`; the exercised Lua is preserved exactly.

## How to Test the Changes:

Follow `plan/client-automation.md` to prepare an isolated `in-world-control-bootstrap` generation,
then run `python3 apps/cata/seed_remaining_object_fields.py <manifest>` before the client run.
Open the equipped Small Brown Pouch manually and inspect the sword and jerky. Check the inventory
overlay, nearby chest, player Corpse, and ground flames. Verify the screen before resetting.
Reuse the built binaries and prepared database; repeat only to investigate an actual failure.

Further gameplay coverage should include random-property/suffix items, corpse save/reload, and
farsight. The current acceptance covers field serialization and representative rendered objects.

## Known Issues and TODO List:

Reforging/transmogrification gameplay, hostile alternative spell visuals, and general item-use,
loot, and cast-request protocol conversion remain separate work.

## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
