### PR TITLE
fix(DB): Native Cataclysm starting spawn and action bar for Human Warrior

### DIFF
--- a/data/sql/updates/pending_db_world/rev_1788973827283357087.sql
+++ b/data/sql/updates/pending_db_world/rev_1788973827283357087.sql
@@ -1,0 +1,16 @@
+-- Human Warrior starting spawn point and action bar: native Cataclysm values.
+-- Source: verified SQL replay of the pinned TDB 434.22011 world update chain, disposable MySQL 8.4.
+-- See apps/cata/fixtures/plan22-starting-data-audit.json (reference_spawn, reference_actions).
+
+DELETE FROM `playercreateinfo` WHERE `race` = 1 AND `class` = 1;
+INSERT INTO `playercreateinfo` (`race`, `class`, `map`, `zone`, `position_x`, `position_y`, `position_z`, `orientation`) VALUES
+(1, 1, 0, 9, -8914.57, -133.909, 80.5378, 5.13806);
+
+DELETE FROM `playercreateinfo_action` WHERE `race` = 1 AND `class` = 1;
+INSERT INTO `playercreateinfo_action` (`race`, `class`, `button`, `action`, `type`) VALUES
+(1, 1, 72, 88163, 0),
+(1, 1, 73, 88161, 0),
+(1, 1, 81, 59752, 0),
+(1, 1, 84, 6603, 0),
+(1, 1, 96, 6603, 0),
+(1, 1, 108, 6603, 0);


### PR DESCRIPTION
## Changes Proposed:

`playercreateinfo` and `playercreateinfo_action` still held WotLK-era spawn
coordinates (map 0, zone 12) and action-bar spells (6603/78/59752) for the
Human Warrior starting profile. This adds a pending world update correcting
both to the verified native Cataclysm values.

- [x] Database (SAI, creatures, etc).

### AI-assisted Pull Requests

> [!IMPORTANT]
> Using AI tools to prepare pull requests is allowed, but it must be disclosed and it must follow our AC guidelines for AI Agentic Engineering.
>
> You are expected to fully understand the changes you submit and to be able to explain and justify them when maintainers ask.

- [x] AI tools were used entirely or partially to prepare this pull request.
  - Tools/models used: Claude Sonnet 5.
- [ ] I have read and understood the [AC guidelines for AI Agentic Engineering](https://www.azerothcore.org/wiki/agentic-engineering)

## Issues Addressed:

Partial implementation of #60, under #57 and #52. These issues remain open pending their acceptance checks.

## SOURCE:

- Reference: The-Cataclysm-Preservation-Project/TrinityCore, pinned at `c699217775d90794158422387b07a917e161b582`.
- Values verified by replaying all 170 pending world updates from the pinned TDB 434.22011 release in a disposable, run-owned MySQL 8.4 container; see `apps/cata/fixtures/plan22-starting-data-audit.json` (`reference_spawn`, `reference_actions`, `reference_database_replay`).

## Tests Performed:

- `python3 apps/codestyle/codestyle-sql.py` passes.
- `python3 apps/cata/audit_character_starting_data.py --self-test` and `python3 apps/cata/check_parity.py --self-test` pass.
- Values cross-checked by hand against the pinned reference fixture; no invented values.
- AC server boot / in-game validation has not run (no local real-client DBC extraction available in this environment).

This pull request has been:

- [ ] Tested in-game by the author.
- [ ] Tested in-game by other community members/someone else other than the author/has been live on production servers.
- [x] This pull request requires further testing and may have edge cases to be tested.

## How to Test the Changes:

- [x] This pull request requires further testing with the setup below.

1. Create an ordinary-account Human Warrior (both genders) at level 1 with collector bonuses and custom starting spells disabled.
2. Confirm the character spawns at map 0, zone 9, `(-8914.57, -133.909, 80.5378)`, orientation `5.13806`.
3. Confirm the action bar matches: button 72 -> 88163, 73 -> 88161, 81 -> 59752, 84/96/108 -> 6603.

## Known Issues and TODO List:

- [ ] Spells 88161/88163 referenced by the new action bar are not yet loaded server-side (tracked under #58's native spell work); the action bar will bind to those IDs once #58 supplies them.
- [ ] Other race/class starting profiles remain unverified and out of scope for this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)